### PR TITLE
Fix segfaults if comment is present in sequence 

### DIFF
--- a/src/mfast/coder/common/FastXMLVisitor.cpp
+++ b/src/mfast/coder/common/FastXMLVisitor.cpp
@@ -259,7 +259,7 @@ FastXMLVisitor::only_child(const XMLElement & element)
 {
   const XMLElement* first_elem = element.FirstChildElement();
   if (strcmp(first_elem->Name(), "length") == 0) {
-    first_elem = first_elem->NextSibling()->ToElement(); 
+      first_elem = first_elem->NextSiblingElement();
   }
   if (first_elem->NextSibling() == 0)
     return first_elem;


### PR DESCRIPTION
If sequence element contains comment node right after the length element, 

```
first_elem = first_elem->NextSibling()->ToElement();
```

returns NULL, so 

```
if (first_elem->NextSibling() == 0)
```

dereferences zero pointer, thus making fast_type_gen crash (I've got this behaviour on Moscow Exchange fast templates)

XMLElement::NextSiblingElement() skips all non-element items, fixing this error.
