### PR TITLE
Fix fast type gen

### DIFF
--- a/src/fast_type_gen/codegen_base.cpp
+++ b/src/fast_type_gen/codegen_base.cpp
@@ -80,6 +80,11 @@ codegen_base::cpp_name(const mfast::field_instruction* inst)
   return cpp_name( inst->name() );
 }
 
+std::string codegen_base::cpp_name(const std::string& str)
+{
+  return cpp_name(str.c_str());
+}
+
 std::string codegen_base::cpp_name(const char* name)
 {
   std::string result;

--- a/src/fast_type_gen/codegen_base.h
+++ b/src/fast_type_gen/codegen_base.h
@@ -53,6 +53,7 @@ protected:
 public:
   codegen_base(const char* filebase, const char* fileext);
   static std::string cpp_name(const mfast::field_instruction* inst);
+  static std::string cpp_name(const std::string& str);
   static std::string cpp_name(const char* n);
   static const  mfast::field_instruction* get_element_instruction(const mfast::sequence_field_instruction* inst);
 protected:

--- a/src/fast_type_gen/cpp_gen.cpp
+++ b/src/fast_type_gen/cpp_gen.cpp
@@ -573,10 +573,11 @@ void cpp_gen::visit(const mfast::templateref_instruction* inst, void* pIndex)
 
 void cpp_gen::generate(mfast::dynamic_templates_description& desc)
 {
+  std::string cpp_filebase = this->cpp_name(filebase_);
   out_<< "#include \"" << filebase_ << ".h\"\n"
       << "\n"
       << "using namespace mfast;\n\n"
-      << "namespace " << filebase_ << "\n{\n";
+      << "namespace " << cpp_filebase << "\n{\n";
 
   this->traverse(desc);
 
@@ -590,7 +591,7 @@ void cpp_gen::generate(mfast::dynamic_templates_description& desc)
   if (instructions.size()) {
     instructions.resize(instructions.size() - 2);
 
-    out_ << "const template_instruction* "<< filebase_ << "_templates_instructions[] ={\n"
+    out_ << "const template_instruction* "<< cpp_filebase << "_templates_instructions[] ={\n"
          << instructions
          << "};\n\n"
          << "templates_description::templates_description()\n"
@@ -598,7 +599,7 @@ void cpp_gen::generate(mfast::dynamic_templates_description& desc)
          << "    \"" << desc.ns()  << "\", // ns\n"
          << "    \"" << desc.template_ns()<< "\", // templateNs\n"
          << "    \"" << desc.dictionary() << "\", // dictionary\n"
-         << "    " << filebase_ << "_templates_instructions)\n"
+         << "    " << cpp_filebase << "_templates_instructions)\n"
          << "{\n"
          << "}\n\n"
          << "const templates_description* templates_description::instance()\n"

--- a/src/fast_type_gen/hpp_gen.cpp
+++ b/src/fast_type_gen/hpp_gen.cpp
@@ -481,7 +481,7 @@ void hpp_gen::generate(mfast::dynamic_templates_description& desc)
 {
   codegen_base::traverse(desc);
 
-  std::string filebase_upper = boost::to_upper_copy(filebase_);
+  std::string filebase_upper = this->cpp_name(boost::to_upper_copy(filebase_));
 
   out_<< "#ifndef __" << filebase_upper << "_H__\n"
       << "#define __" << filebase_upper << "_H__\n"
@@ -499,7 +499,7 @@ void hpp_gen::generate(mfast::dynamic_templates_description& desc)
     out_ << "#include \"" << export_symbol_ << ".h\"\n";
   }
 
-  out_ << "namespace " << filebase_ << "\n{\n"
+  out_ << "namespace " << this->cpp_name(filebase_) << "\n{\n"
        << content_.str()
        << "\n";
 


### PR DESCRIPTION
Hello.
This commits fix error and warning messages from compiler. 
Errors is about napespaces and variables names contains invalid symbols. Warnings is the same but about "#define". 

The reason of this situation is name of xml templates file that contain valid symbols for OS but not for C++ names. 

Maybe better solution is use cpp_name() function on initialization of "filebase_" variable of class "codegen_base". If use the second variant we will get *.h, *.cpp, *.inl files with alphanumeric symbols in their names and valid cpp names inside files.

So, if you want I can do second solution or pull the solution presented in this request. 