### PR TITLE
Fix zero as null pointer constant warnings in fast_type_gen output

### DIFF
--- a/src/fast_type_gen/cpp_gen.cpp
+++ b/src/fast_type_gen/cpp_gen.cpp
@@ -60,7 +60,7 @@ const char *get_presence(const mfast::field_instruction *inst) {
 std::string cpp_gen::gen_op_context(const char *name,
                                     const mfast::op_context_t *context) {
   if (context == nullptr)
-    return "0";
+    return "nullptr";
 
   out_ << "const static "
        << "op_context_t " << prefix_string() << name << "_opContext ={\n"
@@ -454,7 +454,7 @@ void cpp_gen::visit(const mfast::sequence_field_instruction *inst,
     subinstruction_arg << "  " << cpp_type_of(inst->element_instruction())
                        << "::instruction(), // element_instruction\n";
   } else {
-    subinstruction_arg << "  0, // element_instruction\n";
+    subinstruction_arg << "  nullptr, // element_instruction\n";
   }
 
   if (inst->ref_instruction()) {
@@ -589,7 +589,7 @@ void cpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {
   std::stringstream elements_variable_name;
   std::stringstream num_elements_name;
   std::stringstream instruction_type;
-  std::string values_variable_name = "0";
+  std::string values_variable_name = "nullptr";
 
   if (inst->ref_instruction()) {
     qualified_name = cpp_type_of(inst);
@@ -655,8 +655,8 @@ void cpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {
        << "  " << elements_variable_name.str() << ", // element names\n"
        << "  " << values_variable_name << ", // element values\n"
        << "  " << num_elements_name.str() << ",// num elements\n"
-       << "  0, // ref_instruction\n"
-       << "  0, // cpp_ns\n"
+       << "  nullptr, // ref_instruction\n"
+       << "  nullptr, // cpp_ns\n"
        << "  " << inst->tag() << "); //tag \n\n";
 
   if (pIndex == nullptr) {

--- a/src/fast_type_gen/hpp_gen.cpp
+++ b/src/fast_type_gen/hpp_gen.cpp
@@ -625,8 +625,8 @@ void hpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {
                  << indent << "    typedef " << name
                  << "::instruction_type instruction_type;\n" << indent << "    "
                  << name << "_cref(\n" << indent
-                 << "      const mfast::value_storage* storage=0,\n" << indent
-                 << "      instruction_cptr            instruction=0);\n\n"
+                 << "      const mfast::value_storage* storage=nullptr,\n" << indent
+                 << "      instruction_cptr            instruction=nullptr);\n\n"
                  << indent << "    explicit " << name
                  << "_cref(const field_cref& other);\n\n" << indent
                  << "    element_type value() const;\n\n";
@@ -646,9 +646,9 @@ void hpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {
                  << name << "_cref> base_type;\n" << indent << "    typedef "
                  << name << "::element element_type;\n" << indent << "    "
                  << name << "_mref(\n" << indent
-                 << "      mfast::allocator*     alloc=0,\n" << indent
-                 << "      mfast::value_storage* storage=0,\n" << indent
-                 << "      instruction_cptr      instruction=0);\n"
+                 << "      mfast::allocator*     alloc=nullptr,\n" << indent
+                 << "      mfast::value_storage* storage=nullptr,\n" << indent
+                 << "      instruction_cptr      instruction=nullptr);\n"
 
                  << indent << "    explicit " << name
                  << "_mref(const mfast::field_mref_base& other);\n\n";

--- a/src/fast_type_gen/inl_gen.cpp
+++ b/src/fast_type_gen/inl_gen.cpp
@@ -413,8 +413,8 @@ void inl_gen::visit(const mfast::group_field_instruction *inst, void *pIndex) {
     if (inst->optional())
       out_ << "  if ("
            << "(*this)[" << index << "].absent())\n"
-           << "    return " << cref_type_name << "(0, " << cref_type_name
-           << "::instruction_cptr(0));\n";
+           << "    return " << cref_type_name << "(nullptr, " << cref_type_name
+           << "::instruction_cptr(nullptr));\n";
     out_ << "  return static_cast<" << cref_type_name << ">(" << cref_strm.str()
          << ");\n"
          << "}\n\n"
@@ -461,7 +461,7 @@ void inl_gen::visit(const mfast::group_field_instruction *inst, void *pIndex) {
   if (inst->ref_instruction() == nullptr && !embed_only_dyn_tempateref) {
 
     out_ << "inline\n" << cref_type_name << "::" << name << "_cref()\n"
-         << "  : base_type(0, 0)\n"
+         << "  : base_type(nullptr, nullptr)\n"
          << "{\n"
          << "}\n\n"
          << "template <typename T>"
@@ -495,7 +495,7 @@ void inl_gen::visit(const mfast::group_field_instruction *inst, void *pIndex) {
     out_ << "}\n\n";
 
     out_ << "inline\n" << mref_type_name << "::" << name << "_mref()\n"
-         << "  : base_type(0, 0, 0)\n"
+         << "  : base_type(nullptr, nullptr, nullptr)\n"
          << "{\n"
          << "}\n\n"
          << "template <typename T>"
@@ -704,7 +704,7 @@ void inl_gen::visit(const mfast::sequence_field_instruction *inst,
   if (pIndex == nullptr) {
     out_ << "inline\n" << name << "::" << name << "(\n"
          << "  mfast::allocator* alloc)\n"
-         << "  : base_type(alloc, instruction(), 0)\n"
+         << "  : base_type(alloc, instruction(), nullptr)\n"
          << "{\n"
          << "}\n\n"
          << "inline\n" << name << "::" << name << "(\n"
@@ -764,7 +764,7 @@ void inl_gen::visit(const mfast::template_instruction *inst, void *) {
   std::string name(cpp_name(inst));
 
   out_ << "inline\n" << name << "_cref::" << name << "_cref()\n"
-       << "  : base_type(0, 0)\n"
+       << "  : base_type(nullptr, nullptr)\n"
        << "{\n"
        << "}\n\n"
        << "template <typename T>"
@@ -813,7 +813,7 @@ void inl_gen::visit(const mfast::template_instruction *inst, void *) {
   out_ << "}\n\n";
 
   out_ << "inline\n" << name << "_mref::" << name << "_mref()\n"
-       << "  : base_type(0, 0, 0)\n"
+       << "  : base_type(nullptr, nullptr, nullptr)\n"
        << "{\n"
        << "}\n\n"
        << "template <typename T>"


### PR DESCRIPTION
This commit fixes "warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]" warnings in code generated by fast_type_gen.  This helps use fast_type_gen in projects built with errors as warnings.

I realise there are many such errors in boost and in parts of mFAST itself, but this isn't supposed to address that.  This just addresses issues in generated code.