### PR TITLE
Additional fast_type_gen options

### DIFF
--- a/examples/message_printer/CMakeLists.txt
+++ b/examples/message_printer/CMakeLists.txt
@@ -4,7 +4,7 @@
 ##########################################################################
 
 # cmake_minimum_required(VERSION 2.8)
-# find_pacakge(mFAST REQUIRED COMPONENTS coder)
+# find_package(mFAST REQUIRED COMPONENTS coder)
 #
 # include_directories(${MFAST_INCLUDE_DIR})
 # link_directories(${MFAST_LIBRARY_DIRS})

--- a/src/fast_type_gen/codegen_base.cpp
+++ b/src/fast_type_gen/codegen_base.cpp
@@ -18,7 +18,10 @@
 //     along with mFast.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include "codegen_base.h"
+#include <boost/algorithm/string/trim.hpp>
 #include <cctype>
+#include <cstring>
+#include <utility>
 
 codegen_base::codegen_base(const char *filebase, const char *fileext)
     : filebase_(filebase), cpp_ns_(filebase),
@@ -33,6 +36,24 @@ inline bool
 codegen_base::dont_generate(const mfast::field_instruction * /*inst*/) const {
   // return std::strncmp("mfast:", inst->name(), 6) == 0;
   return false;
+}
+
+void codegen_base::set_outer_ns(const char *outer_ns) {
+  outer_ns_.clear();
+  const char *dlt;
+  while (outer_ns) {
+    const char *dlt = std::strstr(outer_ns, "::");
+    std::string comp;
+    if (dlt) {
+        comp.assign(outer_ns, dlt);
+        outer_ns = dlt + 2;
+    } else {
+      comp.assign(outer_ns);
+      outer_ns = nullptr;
+    }
+    boost::algorithm::trim(comp);
+    outer_ns_.push_back(std::move(comp));
+  }
 }
 
 void codegen_base::traverse(mfast::dynamic_templates_description &desc) {

--- a/src/fast_type_gen/codegen_base.h
+++ b/src/fast_type_gen/codegen_base.h
@@ -25,6 +25,7 @@
 #include <mfast/xml_parser/dynamic_templates_description.h>
 #include <fstream>
 #include <set>
+#include <vector>
 
 class file_open_error : public virtual boost::exception,
                         public virtual std::exception {
@@ -38,12 +39,14 @@ public:
 class codegen_base : public mfast::field_instruction_visitor {
 protected:
   std::string filebase_;
+  std::vector<std::string> outer_ns_;
   std::string cpp_ns_;
   std::ofstream out_;
   std::stringstream cref_scope_;
 
 public:
   codegen_base(const char* filebase, const char* fileext);
+  void set_outer_ns(const char *outer_ns);
   static std::string cpp_name(const mfast::field_instruction* inst);
   static std::string cpp_name(boost::string_ref n);
   static const  mfast::field_instruction* get_element_instruction(const mfast::sequence_field_instruction* inst);

--- a/src/fast_type_gen/cpp_gen.cpp
+++ b/src/fast_type_gen/cpp_gen.cpp
@@ -548,7 +548,7 @@ void cpp_gen::visit(const mfast::templateref_instruction *inst, void *pIndex) {
 }
 
 void cpp_gen::generate(mfast::dynamic_templates_description &desc) {
-  out_ << "#include \"" << filebase_ << ".h\"\n"
+  out_ << "#include \"" << filebase_ << hpp_fileext_ << "\"\n"
        << "\n"
        << "using namespace mfast;\n\n"
        << "namespace " << filebase_ << "\n{\n";

--- a/src/fast_type_gen/cpp_gen.cpp
+++ b/src/fast_type_gen/cpp_gen.cpp
@@ -550,8 +550,10 @@ void cpp_gen::visit(const mfast::templateref_instruction *inst, void *pIndex) {
 void cpp_gen::generate(mfast::dynamic_templates_description &desc) {
   out_ << "#include \"" << filebase_ << hpp_fileext_ << "\"\n"
        << "\n"
-       << "using namespace mfast;\n\n"
-       << "namespace " << filebase_ << "\n{\n";
+       << "using namespace mfast;\n\n";
+  for (auto &&ns : outer_ns_)
+    out_ << "namespace " << ns << "\n{\n";
+  out_ << "namespace " << filebase_ << "\n{\n";
 
   this->traverse(desc);
 
@@ -580,6 +582,8 @@ void cpp_gen::generate(mfast::dynamic_templates_description &desc) {
          << "}\n";
   }
   out_ << "\n}\n";
+  for (auto it = outer_ns_.begin(); it != outer_ns_.end(); ++it)
+    out_ << "}\n";
 }
 
 void cpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {

--- a/src/fast_type_gen/cpp_gen.h
+++ b/src/fast_type_gen/cpp_gen.h
@@ -24,7 +24,9 @@
 
 class cpp_gen : public codegen_base {
 public:
-  cpp_gen(const char *filebase) : codegen_base(filebase, ".cpp") {}
+  cpp_gen(const char *filebase, const char *fileext = ".cpp")
+      : codegen_base(filebase, fileext), hpp_fileext_(".h") {}
+  void set_hpp_fileext(const char *hpp_fileext) { hpp_fileext_ = hpp_fileext; }
   void generate(mfast::dynamic_templates_description &desc);
 
   virtual void visit(const mfast::int32_field_instruction *, void *) override;
@@ -77,6 +79,7 @@ private:
   bool
   need_generate_subinstructions(const mfast::group_field_instruction *inst);
 
+  std::string hpp_fileext_;
   std::vector<std::string> subinstructions_list_;
   std::stringstream template_instructions_;
   std::vector<std::string> prefixes_;

--- a/src/fast_type_gen/fast_type_gen.cpp
+++ b/src/fast_type_gen/fast_type_gen.cpp
@@ -33,16 +33,110 @@
 
 // using namespace boost::filesystem;
 
+bool check_long_option(const std::string &command, int argc, const char **argv, int &i, const char *name, const char *&output, bool &bad) {
+  const auto len = std::strlen(name);
+  if (std::strncmp(argv[i], name, len) != 0) {
+    return false;
+  } else if (argv[i][len] == '=') {
+    output = &argv[i][len + 1];
+    return true;
+  } else if (argv[i][len] == '\0') {
+    if (++i < argc) {
+      output = argv[i];
+    } else {
+      std::cerr << command << ": option requires and argument -- " << name << std::endl;
+      bad = true;
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool check_short_option(const std::string &command, int argc, const char **argv, int &i, const char *&arg, char flag, const char *&output, bool bad)
+{
+  if (*arg == flag) {
+    if (*++arg != '\0') {
+      output = arg;
+      arg += std::strlen(arg);
+    } else if (++i < argc) {
+      arg = output = argv[i];
+      arg += std::strlen(arg);
+    }
+    else {
+      std::cerr << command << ": option requires and argument -- " << flag << std::endl;
+      bad = true;
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
 int main(int argc, const char **argv) {
   mfast::template_registry registry;
 
   try {
     int i = 1;
-    const char *export_symbol = nullptr;
 
-    if (std::strcmp(argv[1], "-E") == 0) {
-      export_symbol = argv[2];
-      i = 3;
+    std::string command_name = "fast_type_gen";
+
+    const char *export_symbol = nullptr;
+    const char *header_extension = ".h";
+    const char *inline_extension = ".inl";
+    const char *source_extension = ".cpp";
+
+    bool show_usage = false;
+    bool bad_arguments = false;
+
+    while ((i < argc) && (std::strlen(argv[i]) > 1) && (argv[i][0] == '-') && (std::strcmp(argv[i], "--") != 0) && !bad_arguments) {
+      const char *flag = &argv[i][1];
+      if (*flag == '-') {
+        ++flag;
+        if (std::strcmp(flag, "help") == 0) {
+          show_usage = true;
+        } else if (check_long_option(command_name, argc, argv, i, "--export-symbol", export_symbol, bad_arguments)) {
+        } else if (check_long_option(command_name, argc, argv, i, "--header-extension", header_extension, bad_arguments)) {
+        } else if (check_long_option(command_name, argc, argv, i, "--inline-extension", inline_extension, bad_arguments)) {
+        } else if (check_long_option(command_name, argc, argv, i, "--source-extension", source_extension, bad_arguments)) {
+        } else {
+          std::cerr << command_name << ": illegal option -- " << flag << std::endl;
+          bad_arguments = true;
+        }
+      } else {
+        while ((i < argc) && *flag && !bad_arguments) {
+          if (*flag == 'h') {
+            show_usage = true;
+            ++flag;
+          } else if (check_short_option(command_name, argc, argv, i, flag, 'E', export_symbol, bad_arguments)) {
+          } else if (check_short_option(command_name, argc, argv, i, flag, 'H', header_extension, bad_arguments)) {
+          } else if (check_short_option(command_name, argc, argv, i, flag, 'I', inline_extension, bad_arguments)) {
+          } else if (check_short_option(command_name, argc, argv, i, flag, 'C', source_extension, bad_arguments)) {
+          } else {
+            std::cerr << command_name << ": illegal option -- " << *flag << std::endl;
+            bad_arguments = true;
+          }
+        }
+      }
+      ++i;
+    }
+    if ((i < argc) && (std::strcmp(argv[i], "--") == 0))
+      ++i;
+    if (show_usage || bad_arguments || (i >= argc)) {
+      std::ostream &output = show_usage ? std::cout : std::cerr;
+      output << "usage: " << command_name << " [-E symbol] [-H extension] [-I extension] [-C extension] file ...\n"
+                "       generate C++ bindings for FAST types\n";
+      if (show_usage) {
+        output << "\n"
+                  "Options and arguments:\n"
+                  "  -h, --help                  show usage and exit\n"
+                  "  -E, --export-symbol=SYM     qualifier for generated types\n"
+                  "  -C, --source-extension=EXT  source filename extension (default .cpp)\n"
+                  "  -H, --header-extension=EXT  header filename extension (default .h)\n"
+                  "  -I, --inline-extension=EXT  inline function filename extension (default .inl)\n"
+                  "  file ...                    XML FAST message template inputs\n";
+      }
+      return (bad_arguments || (!show_usage && (i >= argc))) ? -1 : 0;
     }
 
     std::vector<mfast::dynamic_templates_description> descriptions;
@@ -56,7 +150,7 @@ int main(int argc, const char **argv) {
       std::ifstream ifs(argv[i]);
 
       if (!ifs) {
-        std::cerr << argv[i] << " load failed\n";
+        std::cerr << command_name << ": " << argv[i] << " load failed" << std::endl;
         return -1;
       }
 
@@ -85,15 +179,17 @@ int main(int argc, const char **argv) {
       mfast::dynamic_templates_description &desc = descriptions[j];
       const std::string &filebase = filebases[j];
 
-      hpp_gen header_gen(filebase.c_str());
+      hpp_gen header_gen(filebase.c_str(), header_extension);
       if (export_symbol)
         header_gen.set_export_symbol(export_symbol);
+      header_gen.set_inl_fileext(inline_extension);
       header_gen.generate(desc);
 
-      inl_gen inline_gen(filebase.c_str());
+      inl_gen inline_gen(filebase.c_str(), inline_extension);
       inline_gen.generate(desc);
 
-      cpp_gen source_gen(filebase.c_str());
+      cpp_gen source_gen(filebase.c_str(), source_extension);
+      source_gen.set_hpp_fileext(header_extension);
       source_gen.generate(desc);
     }
   } catch (boost::exception &e) {

--- a/src/fast_type_gen/fast_type_gen.cpp
+++ b/src/fast_type_gen/fast_type_gen.cpp
@@ -82,6 +82,7 @@ int main(int argc, const char **argv) {
     std::string command_name = "fast_type_gen";
 
     const char *export_symbol = nullptr;
+    const char *outer_namespace = nullptr;
     const char *header_extension = ".h";
     const char *inline_extension = ".inl";
     const char *source_extension = ".cpp";
@@ -96,6 +97,7 @@ int main(int argc, const char **argv) {
         if (std::strcmp(flag, "help") == 0) {
           show_usage = true;
         } else if (check_long_option(command_name, argc, argv, i, "--export-symbol", export_symbol, bad_arguments)) {
+        } else if (check_long_option(command_name, argc, argv, i, "--namespace", outer_namespace, bad_arguments)) {
         } else if (check_long_option(command_name, argc, argv, i, "--header-extension", header_extension, bad_arguments)) {
         } else if (check_long_option(command_name, argc, argv, i, "--inline-extension", inline_extension, bad_arguments)) {
         } else if (check_long_option(command_name, argc, argv, i, "--source-extension", source_extension, bad_arguments)) {
@@ -109,6 +111,7 @@ int main(int argc, const char **argv) {
             show_usage = true;
             ++flag;
           } else if (check_short_option(command_name, argc, argv, i, flag, 'E', export_symbol, bad_arguments)) {
+          } else if (check_short_option(command_name, argc, argv, i, flag, 'n', outer_namespace, bad_arguments)) {
           } else if (check_short_option(command_name, argc, argv, i, flag, 'H', header_extension, bad_arguments)) {
           } else if (check_short_option(command_name, argc, argv, i, flag, 'I', inline_extension, bad_arguments)) {
           } else if (check_short_option(command_name, argc, argv, i, flag, 'C', source_extension, bad_arguments)) {
@@ -131,6 +134,7 @@ int main(int argc, const char **argv) {
                   "Options and arguments:\n"
                   "  -h, --help                  show usage and exit\n"
                   "  -E, --export-symbol=SYM     qualifier for generated types\n"
+                  "  -n, --namespace=NS          namespace for generated code\n"
                   "  -C, --source-extension=EXT  source filename extension (default .cpp)\n"
                   "  -H, --header-extension=EXT  header filename extension (default .h)\n"
                   "  -I, --inline-extension=EXT  inline function filename extension (default .inl)\n"
@@ -180,15 +184,21 @@ int main(int argc, const char **argv) {
       const std::string &filebase = filebases[j];
 
       hpp_gen header_gen(filebase.c_str(), header_extension);
+      if (outer_namespace)
+        header_gen.set_outer_ns(outer_namespace);
       if (export_symbol)
         header_gen.set_export_symbol(export_symbol);
       header_gen.set_inl_fileext(inline_extension);
       header_gen.generate(desc);
 
       inl_gen inline_gen(filebase.c_str(), inline_extension);
+      if (outer_namespace)
+        inline_gen.set_outer_ns(outer_namespace);
       inline_gen.generate(desc);
 
       cpp_gen source_gen(filebase.c_str(), source_extension);
+      if (outer_namespace)
+        source_gen.set_outer_ns(outer_namespace);
       source_gen.set_hpp_fileext(header_extension);
       source_gen.generate(desc);
     }

--- a/src/fast_type_gen/hpp_gen.cpp
+++ b/src/fast_type_gen/hpp_gen.cpp
@@ -545,6 +545,8 @@ void hpp_gen::generate(mfast::dynamic_templates_description &desc) {
     out_ << "#include \"" << export_symbol_ << ".h\"\n";
   }
 
+  for (auto &&ns : outer_ns_)
+    out_ << "namespace " << ns << "\n{\n";
   out_ << "namespace " << filebase_ << "\n{\n" << content_.str() << "\n";
 
   for (const mfast::aggregate_view_info &info : desc.view_infos()) {
@@ -582,7 +584,9 @@ void hpp_gen::generate(mfast::dynamic_templates_description &desc) {
   }
 
   out_ << "#include \"" << filebase_ << inl_fileext_ << "\"\n"
-       << "}\n\n";
+       << "}\n";
+  for (auto it = outer_ns_.begin(); it != outer_ns_.end(); ++it)
+    out_ << "}\n";
 }
 
 void hpp_gen::visit(const mfast::enum_field_instruction *inst, void *pIndex) {

--- a/src/fast_type_gen/hpp_gen.cpp
+++ b/src/fast_type_gen/hpp_gen.cpp
@@ -538,7 +538,7 @@ void hpp_gen::generate(mfast::dynamic_templates_description &desc) {
 
   for (const std::string &dep : dependency_) {
     if (dep != "mfast")
-      out_ << "#include \"" << dep << ".h\"\n";
+      out_ << "#include \"" << dep << hpp_fileext_ << "\"\n";
   }
 
   if (export_symbol_.size()) {
@@ -581,7 +581,7 @@ void hpp_gen::generate(mfast::dynamic_templates_description &desc) {
          << "}\n\n";
   }
 
-  out_ << "#include \"" << filebase_ << ".inl\"\n"
+  out_ << "#include \"" << filebase_ << inl_fileext_ << "\"\n"
        << "}\n\n";
 }
 

--- a/src/fast_type_gen/hpp_gen.h
+++ b/src/fast_type_gen/hpp_gen.h
@@ -25,8 +25,10 @@
 
 class hpp_gen : public codegen_base {
 public:
-  hpp_gen(const char *filebase) : codegen_base(filebase, ".h") {}
+  hpp_gen(const char *filebase, const char *fileext = ".h")
+      : codegen_base(filebase, fileext), inl_fileext_(".inl"), hpp_fileext_(fileext) {}
   void set_export_symbol(const char *symbol);
+  void set_inl_fileext(const char *inl_fileext) { inl_fileext_ = inl_fileext; }
   void generate(mfast::dynamic_templates_description &desc);
 
   virtual void visit(const mfast::int32_field_instruction *, void *) override;
@@ -63,6 +65,8 @@ private:
                             const std::string &name);
 
   typedef indented_stringstream ind_stream;
+  std::string hpp_fileext_;
+  std::string inl_fileext_;
   std::set<std::string> dependency_;
   ind_stream header_cref_;
   ind_stream header_mref_;

--- a/src/fast_type_gen/inl_gen.h
+++ b/src/fast_type_gen/inl_gen.h
@@ -23,7 +23,7 @@
 
 class inl_gen : public codegen_base {
 public:
-  inl_gen(const char *filebase) : codegen_base(filebase, ".inl") {}
+  inl_gen(const char *filebase, const char *fileext = ".inl") : codegen_base(filebase, fileext) {}
   void generate(mfast::dynamic_templates_description &desc);
 
   virtual void visit(const mfast::int32_field_instruction *, void *) override;


### PR DESCRIPTION
This patch improves the command-line interface of fast_type_gen and adds additional options to make the generated code easier to use in other projects.  No additional link dependencies have been added.

Long and short option syntax is supported, the following are all handled equivalently:

    fast_type_gen -Emy_export template.xml
    fast_type_gen -E my_export template.xml
    fast_type_gen -export-symbol=my_export template.xml
    fast_type_gen -export-symbol my_export template.xml

You can use `--` to prevent subsequent arguments from being interpreted as options:

    fast_type_get -- -silly_path/template.xml

Terse usage information is printed to standard error if fast_type_gen is invoked with invalid options or no input files.  An option `-h` or `--help` has been added to print detailed usage information standard output and exit without processing any inputs.

Options have been added to set filename extensions, to allow the output to fit better in an environment where a different convention is used (e.g. .hxx for headers or .ipp for inline source).  Default behaviour is unchanged.  I'd be happy to change the names of the options if you don't like my choices

    fast_type_gen -H .hxx -I .ixx -C .cxx template.xml
    fast_type_gen --header-extension=.hxx --inline-extension=.ixx --source-extension=.cxx template.xml

An option has been added to enclose the generated code in an additional namespace.  No real validation is performed so it's easy enough to abuse this to generate invalid code, but valid C++ namespaces work as expected:

    fast_type_gen -n outer::ns template.xml
    fast_type_gen -n "outer :: ns" template.xml
    fast_type_gen --namepsace=outer_ns" template.xml
    fast_type_gen --namespace="multi :: level :: ns" template.xml

A typo in a comment in the message_printer CMakeLists.txt has also been fixed.