### PR TITLE
Improve handling of include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ else()
 endif()
 
 # Create the mFASTConfig.cmake for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src" "${PROJECT_BINARY_DIR}")
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src")
 configure_file(mFASTConfig.cmake.in
                "${PROJECT_BINARY_DIR}/mFASTConfig.cmake"
                @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,8 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "build shared/dynamic library")
 # Offer the user the choice of overriding the installation directories
 set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
-set(INSTALL_INCLUDE_DIR include CACHE PATH
-"Installation directory for header files")
-set(INSTALL_DATA_DIR share CACHE PATH
-"Installation directory for data files")
+set(INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
+set(INSTALL_DATA_DIR share CACHE PATH "Installation directory for data files")
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -61,16 +59,12 @@ set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
 "Installation directory for CMake files")
 
 # Make relative paths absolute (needed later on)
-foreach(p LIB BIN DATA CMAKE)
-set(var INSTALL_${p}_DIR)
-if(NOT IS_ABSOLUTE "${${var}}")
- set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-endif()
-endforeach()
-
-if(NOT IS_ABSOLUTE "${INSTALL_INCLUDE_DIR}")
- set(INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
-endif()
+foreach (p IN ITEMS LIB BIN INCLUDE DATA CMAKE)
+  set (var "INSTALL_${p}_DIR")
+  if (NOT IS_ABSOLUTE "${${var}}")
+    set("${var}" "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif ()
+endforeach (p)
 
 
 include_directories ("${PROJECT_BINARY_DIR}"

--- a/mFASTConfig.cmake.in
+++ b/mFASTConfig.cmake.in
@@ -12,7 +12,11 @@ get_filename_component(MFAST_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include("${MFAST_CMAKE_DIR}/mFASTTargets.cmake")
 
 find_package( Boost 1.55.0 )
-set(MFAST_INCLUDE_DIR ${Boost_INCLUDE_DIR} "@CONF_INCLUDE_DIRS@")
+set(MFAST_INCLUDE_DIR "${Boost_INCLUDE_DIR}")
+foreach (directory @CONF_INCLUDE_DIRS@)
+  get_filename_component(directory "${directory}" ABSOLUTE)
+  list(APPEND MFAST_INCLUDE_DIR "${directory}")
+endforeach (directory)
 set(MFAST_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
 
 list(REMOVE_DUPLICATES MFAST_INCLUDE_DIR)


### PR DESCRIPTION
* Don't add the build directory to the configured include paths for the exported configuration, it isn't necessary.
* Handle relative INSTALL_INCLUDE_DIR so that something like `-DINSTALL_INCLUDE_DIR:STRING=include/mfast-1.3` will work as expected.  Currently relative INSTALL_INCLUDE_DIR is not honoured at all.
* Convert the configured include path(s) to absolute paths in mFASTConfig.cmake to improve behaviour in cases where INSTALL_CMAKE_DIR contains symbolic links.