### PR TITLE
Fix target export for build tree, clean up CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,10 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-warn-absolute-paths -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s OUTLINING_LIMIT=20000")
 endif()
 # variables to be used later
+set(MFAST_SHARED_LIBRARIES CACHE INTERNAL "")
+set(MFAST_STATIC_LIBRARIES CACHE INTERNAL "")
 set(MFAST_DYNAMIC_COMPONENTS CACHE INTERNAL "")
 set(MFAST_STATIC_COMPONENTS CACHE INTERNAL "")
-set(MFAST_LIBRARY CACHE INTERNAL "")
 
 ############################################################################
 # Setting up RPATH
@@ -130,7 +131,7 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_subdirectory (src)
 
-link_directories (${PROJECT_BINARY_DIR}/src)
+link_directories ("${PROJECT_BINARY_DIR}/src")
 
 #============================================================
 # Install fast_type_gen batch file to set up the PATH environment
@@ -209,11 +210,11 @@ enable_testing()
 add_subdirectory (tests)
 
 if (BUILD_SHARED_LIBS)
-  set(MFAST_LIBRARIES mfast_coder mfast_xml_parser mfast)
-  add_definitions( -DMFAST_DYN_LINK )
-else()
-  set(MFAST_LIBRARIES mfast_coder_static mfast_xml_parser_static mfast_static)
-endif()
+  set(MFAST_LIBRARIES "${MFAST_SHARED_LIBRARIES}")
+  add_definitions(-DMFAST_DYN_LINK)
+else (BUILD_SHARED_LIBS)
+  set(MFAST_LIBRARIES "${MFAST_STATIC_LIBRARIES}")
+endif (BUILD_SHARED_LIBS)
 
 add_subdirectory (examples)
 
@@ -230,15 +231,16 @@ add_custom_target(dist
 # Provide mfast-config.cmake and mfast-config.version to be used by other applications
 # ===============================
 
-if (NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 2.8)
-  export(PACKAGE ${CMAKE_PROJECT_NAME})
-endif(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 2.8)
+export(PACKAGE ${CMAKE_PROJECT_NAME})
 
 if (BUILD_FAST_TYPE_GEN)
-  export(TARGETS fast_type_gen ${MFAST_LIBRARIES} FILE "${PROJECT_BINARY_DIR}/mFASTTargets.cmake")
-else()
+  export(TARGETS fast_type_gen ${MFAST_SHARED_LIBRARIES} ${MFAST_STATIC_LIBRARIES}
+         FILE "${PROJECT_BINARY_DIR}/mFASTTargets.cmake")
+ else (BUILD_FAST_TYPE_GEN)
+  export(TARGETS ${MFAST_SHARED_LIBRARIES} ${MFAST_STATIC_LIBRARIES}
+         FILE "${PROJECT_BINARY_DIR}/mFASTTargets.cmake")
   set(FAST_TYPE_GEN_INSTALL_LOCATION ${FAST_TYPE_GEN})
-endif()
+endif (BUILD_FAST_TYPE_GEN)
 
 # Create the mFASTConfig.cmake for the build tree
 set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src" "${PROJECT_BINARY_DIR}")

--- a/src/mfast/CMakeLists.txt
+++ b/src/mfast/CMakeLists.txt
@@ -27,11 +27,6 @@ set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_static CACHE INTERNAL
 
 if (BUILD_SHARED_LIBS)
   add_library(mfast SHARED ${mfast_SRCS})
-  # the add_dependencies is necessary for CMake 2.6.4. Otherwise, the shared
-  # library would be built before the static library, and the shared library
-  # would be deleted when the static library is built. For CMake 2.8.x, there
-  # is no such problem.
-  add_dependencies(mfast mfast_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
     set_target_properties(mfast PROPERTIES COMPILE_FLAGS -fvisibility=hidden)

--- a/src/mfast/CMakeLists.txt
+++ b/src/mfast/CMakeLists.txt
@@ -20,7 +20,9 @@ set_target_properties(mfast_static PROPERTIES COMPILE_FLAGS -DMFAST_STATIC_DEFIN
 install(TARGETS mfast_static
         EXPORT  mFASTTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-		ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+
+set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_static CACHE INTERNAL "")
 
 
 if (BUILD_SHARED_LIBS)
@@ -32,18 +34,16 @@ if (BUILD_SHARED_LIBS)
   add_dependencies(mfast mfast_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
-	set_target_properties(mfast PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
+    set_target_properties(mfast PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
 
   install(TARGETS mfast
           EXPORT  mFASTTargets
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-  	      LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
-  SET(MFAST_LIBRARY mfast CACHE INTERNAL "mFast Library name")
-else()
-  SET(MFAST_LIBRARY mfast_static CACHE INTERNAL "mFast Library name")
-endif()
+  set(MFAST_SHARED_LIBRARIES ${MFAST_SHARED_LIBRARIES} mfast CACHE INTERNAL "")
+endif (BUILD_SHARED_LIBS)
 
 add_subdirectory (coder)
 add_subdirectory (xml_parser)

--- a/src/mfast/coder/CMakeLists.txt
+++ b/src/mfast/coder/CMakeLists.txt
@@ -27,18 +27,12 @@ set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} coder_static CACHE INTERN
 
 if (BUILD_SHARED_LIBS)
   add_library(mfast_coder SHARED ${mfast_coder_SRCS})
-  # the add_dependencies is necessary for CMake 2.6.4. Otherwise, the shared
-  # library would be built before the static library, and the shared library
-  # would be deleted when the static library is built. For CMake 2.8.x, there
-  # is no such problem.
-  add_dependencies(mfast_coder mfast_coder_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
     set_target_properties(mfast_coder PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
   target_link_libraries(mfast_coder mfast)
   set_target_properties(mfast_coder PROPERTIES COMPILE_FLAGS -DMFAST_DYN_LINK)
-
 
   install(TARGETS mfast_coder
           EXPORT  mFASTTargets

--- a/src/mfast/coder/CMakeLists.txt
+++ b/src/mfast/coder/CMakeLists.txt
@@ -9,16 +9,20 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 set(mfast_coder_SRCS ${sources} ${headers})
 
 add_library(mfast_coder_static STATIC ${mfast_coder_SRCS})
+target_link_libraries(mfast_coder_static mfast_static)
 
 if (UNIX)
-	set_target_properties(mfast_coder_static PROPERTIES OUTPUT_NAME mfast_coder)
+  set_target_properties(mfast_coder_static PROPERTIES OUTPUT_NAME mfast_coder)
 endif()
 set_target_properties(mfast_coder_static PROPERTIES COMPILE_FLAGS -DMFAST_CODER_STATIC_DEFINE)
 
 install(TARGETS mfast_coder_static
         EXPORT  mFASTTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-		ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+
+set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_coder_static CACHE INTERNAL "")
+set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} coder_static CACHE INTERNAL "")
 
 
 if (BUILD_SHARED_LIBS)
@@ -30,7 +34,7 @@ if (BUILD_SHARED_LIBS)
   add_dependencies(mfast_coder mfast_coder_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
-	set_target_properties(mfast_coder PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
+    set_target_properties(mfast_coder PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
   target_link_libraries(mfast_coder mfast)
   set_target_properties(mfast_coder PROPERTIES COMPILE_FLAGS -DMFAST_DYN_LINK)
@@ -39,12 +43,11 @@ if (BUILD_SHARED_LIBS)
   install(TARGETS mfast_coder
           EXPORT  mFASTTargets
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-  	      LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
-  SET(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} coder CACHE INTERNAL "")
-endif()
-
-SET(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} coder_static CACHE INTERNAL "")
+  set(MFAST_SHARED_LIBRARIES ${MFAST_SHARED_LIBRARIES} mfast_coder CACHE INTERNAL "")
+  set(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} coder CACHE INTERNAL "")
+endif (BUILD_SHARED_LIBS)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         DESTINATION "${INSTALL_INCLUDE_DIR}/mfast"

--- a/src/mfast/json/CMakeLists.txt
+++ b/src/mfast/json/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 set(mfast_json_SRCS  ${sources} ${headers})
 
 add_library(mfast_json_static STATIC ${mfast_json_SRCS})
+target_link_libraries(mfast_json_static mfast_static)
 
 if (UNIX)
 	set_target_properties(mfast_json_static PROPERTIES OUTPUT_NAME mfast_json)
@@ -18,7 +19,10 @@ set_target_properties(mfast_json_static PROPERTIES COMPILE_FLAGS -DMFAST_JSON_ST
 install(TARGETS mfast_json_static
         EXPORT  mFASTTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-		ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+
+set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_json_static CACHE INTERNAL "")
+set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} json_static CACHE INTERNAL "")
 
 
 if (BUILD_SHARED_LIBS)
@@ -30,7 +34,7 @@ if (BUILD_SHARED_LIBS)
   add_dependencies(mfast_json mfast_json_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
-	set_target_properties(mfast_json PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
+    set_target_properties(mfast_json PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
   target_link_libraries(mfast_json mfast)
   set_target_properties(mfast_json PROPERTIES COMPILE_FLAGS -DMFAST_DYN_LINK)
@@ -38,14 +42,11 @@ if (BUILD_SHARED_LIBS)
   install(TARGETS mfast_json
           EXPORT  mFASTTargets
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-  	      LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
-  SET(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} json CACHE INTERNAL "")
-endif()
-
-  SET(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} json_static CACHE INTERNAL "")
-
-
+  set(MFAST_SHARED_LIBRARIES ${MFAST_SHARED_LIBRARIES} mfast_json CACHE INTERNAL "")
+  set(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} json CACHE INTERNAL "")
+endif (BUILD_SHARED_LIBS)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         DESTINATION "${INSTALL_INCLUDE_DIR}/mfast"

--- a/src/mfast/json/CMakeLists.txt
+++ b/src/mfast/json/CMakeLists.txt
@@ -27,11 +27,6 @@ set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} json_static CACHE INTERNA
 
 if (BUILD_SHARED_LIBS)
   add_library(mfast_json SHARED ${mfast_json_SRCS})
-  # the add_dependencies is necessary for CMake 2.6.4. Otherwise, the shared
-  # library would be built before the static library, and the shared library
-  # would be deleted when the static library is built. For CMake 2.8.x, there
-  # is no such problem.
-  add_dependencies(mfast_json mfast_json_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
     set_target_properties(mfast_json PROPERTIES COMPILE_FLAGS -fvisibility=hidden)

--- a/src/mfast/sqlite3/CMakeLists.txt
+++ b/src/mfast/sqlite3/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 set(mfast_sqlite3_SRCS  ${sources} ${headers})
 
 add_library(mfast_sqlite3_static STATIC ${mfast_sqlite3_SRCS})
+target_link_libraries(mfast_sqlite3_static mfast_static)
 
 if (UNIX)
 	set_target_properties(mfast_sqlite3_static PROPERTIES OUTPUT_NAME mfast_sqlite3)
@@ -15,8 +16,11 @@ set_target_properties(mfast_sqlite3_static PROPERTIES COMPILE_FLAGS -DMFAST_SQLI
 install(TARGETS mfast_sqlite3_static
         EXPORT  mFASTTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-		ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
         OPTIONAL)
+
+set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_sqlite3_static CACHE INTERNAL "")
+set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} sqlite3_static CACHE INTERNAL "")
 
 
 if (BUILD_SHARED_LIBS)
@@ -37,13 +41,13 @@ if (BUILD_SHARED_LIBS)
   install(TARGETS mfast_sqlite3
           EXPORT  mFASTTargets
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-  	      LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
+          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
           OPTIONAL)
 
-  SET(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} sqlite3 CACHE INTERNAL "")
-endif()
+  set(MFAST_SHARED_LIBRARIES ${MFAST_SHARED_LIBRARIES} mfast_sqlite3 CACHE INTERNAL "")
+  set(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} sqlite3 CACHE INTERNAL "")
+endif (BUILD_SHARED_LIBS)
 
-SET(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} sqlite3_static CACHE INTERNAL "")
 install(FILES mfast_sqlite3_export.h converter.h field_masks.h
         DESTINATION "${INSTALL_INCLUDE_DIR}/mfast/sqlite3"
         OPTIONAL)

--- a/src/mfast/sqlite3/CMakeLists.txt
+++ b/src/mfast/sqlite3/CMakeLists.txt
@@ -25,14 +25,9 @@ set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} sqlite3_static CACHE INTE
 
 if (BUILD_SHARED_LIBS)
   add_library(mfast_sqlite3 SHARED ${mfast_sqlite3_SRCS})
-  # the add_dependencies is necessary for CMake 2.6.4. Otherwise, the shared
-  # library would be built before the static library, and the shared library
-  # would be deleted when the static library is built. For CMake 2.8.x, there
-  # is no such problem.
-  add_dependencies(mfast_sqlite3 mfast_sqlite3_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
-	set_target_properties(mfast_sqlite3 PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
+    set_target_properties(mfast_sqlite3 PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
   target_link_libraries(mfast_sqlite3 mfast sqlite3)
   set_target_properties(mfast_sqlite3 PROPERTIES COMPILE_FLAGS -DMFAST_DYN_LINK)

--- a/src/mfast/xml_parser/CMakeLists.txt
+++ b/src/mfast/xml_parser/CMakeLists.txt
@@ -30,14 +30,9 @@ set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} xml_parser_static CACHE I
 
 if (BUILD_SHARED_LIBS)
   add_library(mfast_xml_parser SHARED ${mfast_xml_parser_SRCS})
-  # the add_dependencies is necessary for CMake 2.6.4. Otherwise, the shared
-  # library would be built before the static library, and the shared library
-  # would be deleted when the static library is built. For CMake 2.8.x, there
-  # is no such problem.
-  add_dependencies(mfast_xml_parser mfast_xml_parser_static)
 
   if (CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
-	set_target_properties(mfast_xml_parser PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
+    set_target_properties(mfast_xml_parser PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
   endif()
   target_link_libraries(mfast_xml_parser mfast)
   set_target_properties(mfast_xml_parser PROPERTIES COMPILE_FLAGS -DMFAST_DYN_LINK)

--- a/src/mfast/xml_parser/CMakeLists.txt
+++ b/src/mfast/xml_parser/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories("${CMAKE_SOURCE_DIR}/tinyxml2")
 set(mfast_xml_parser_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/../../../tinyxml2/tinyxml2.cpp ${sources} ${headers})
 
 add_library(mfast_xml_parser_static STATIC ${mfast_xml_parser_SRCS})
+target_link_libraries(mfast_xml_parser_static mfast_static)
 
 if (UNIX)
 	set_target_properties(mfast_xml_parser_static PROPERTIES OUTPUT_NAME mfast_xml_parser)
@@ -21,7 +22,10 @@ set_target_properties(mfast_xml_parser_static PROPERTIES LINKER_LANGUAGE CXX)
 install(TARGETS mfast_xml_parser_static
         EXPORT  mFASTTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-		ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+
+set(MFAST_STATIC_LIBRARIES ${MFAST_STATIC_LIBRARIES} mfast_xml_parser_static CACHE INTERNAL "")
+set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} xml_parser_static CACHE INTERNAL "")
 
 
 if (BUILD_SHARED_LIBS)
@@ -43,12 +47,11 @@ if (BUILD_SHARED_LIBS)
   install(TARGETS mfast_xml_parser
           EXPORT  mFASTTargets
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-  	      LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
+          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
+  set(MFAST_SHARED_LIBRARIES ${MFAST_SHARED_LIBRARIES} mfast_xml_parser CACHE INTERNAL "")
   set(MFAST_DYNAMIC_COMPONENTS ${MFAST_DYNAMIC_COMPONENTS} xml_parser CACHE INTERNAL "")
-endif()
-
-set(MFAST_STATIC_COMPONENTS ${MFAST_STATIC_COMPONENTS} xml_parser_static CACHE INTERNAL "")
+endif (BUILD_SHARED_LIBS)
 
 install(FILES mfast_xml_parser_export.h dynamic_templates_description.h
         DESTINATION "${INSTALL_INCLUDE_DIR}/mfast/xml_parser")


### PR DESCRIPTION
* Fix target export for build tree.  Currently static library targets are not exported if shared libraries are built, sqlite3 library targets are never exported, and no library targets are exported if fast_type_gen is not built.  This patch ensures all libraries are exported.
* Use target_link_libraries for static libraries.  This doesn't affect how the static libraries are built, but it populates the LINK_INTERFACE property, allowing CMake to automatically give libraries to the linker in the correct order on platforms where this is important.
* Remove some obsolete code for supporting CMake 2.6 since top-level CMakeLists.txt requires CMake 2.8.0 minimum.
* Remove unused MFAST_LIBRARY CMake cache variable.
* Make some spacing/quoting more consistent.