### PR TITLE
Fix one more zero as null pointer constant warning in generated code

### DIFF
--- a/src/fast_type_gen/cpp_gen.cpp
+++ b/src/fast_type_gen/cpp_gen.cpp
@@ -701,7 +701,7 @@ void cpp_gen::generate(const mfast::aggregate_view_info &info) {
     out_ << "    {" << info.data_[i].prop << "ULL, __" << my_name
          << "__indeces__ + " << indeces_sizes[i] << "},\n";
   }
-  out_ << "    {0, 0}\n"
+  out_ << "    {0, nullptr}\n"
        << "  };\n\n"
        << "}//namespace\n\n";
 


### PR DESCRIPTION
Very small change to fix hopefully the last zero as null pointer constant warning in code generated by fast_type_gen.