### PR TITLE
Fix: optional decimal delta value is not written into stream.

### DIFF
--- a/src/mfast/coder/encoder_v2/fast_encoder_core.h
+++ b/src/mfast/coder/encoder_v2/fast_encoder_core.h
@@ -529,6 +529,8 @@ void fast_encoder_core::encode_field(const T &ext_ref, delta_operator_tag,
     delta_storage.of_decimal.mantissa_ =
         cref.mantissa() - bv.of_decimal.mantissa_;
 
+    delta_storage.present(true);
+
     decimal_cref delta(&delta_storage, cref.instruction());
     strm_ << T(delta);
 


### PR DESCRIPTION
When writing optional decimal delta value, delta is computed as follows:

    value_storage delta_storage;
    delta_storage.of_decimal.exponent_ =
        cref.exponent() - bv.of_decimal.exponent_;
    delta_storage.of_decimal.mantissa_ =
        cref.mantissa() - bv.of_decimal.mantissa_;
    decimal_cref delta(&delta_storage, cref.instruction());

After this it is written to stream. 
But present_ flag of delta_storage is set to 0.
So, null value is written.

Schema of encoded value:
`<decimal name="MDEntryPx" id="270" presence="optional">
    <delta value="0"/>
</decimal>`
