### PR TITLE
Reset active_message_info_ when encode is called with force_reset = true

### DIFF
--- a/src/mfast/coder/encoder_v2/fast_encoder_core.cpp
+++ b/src/mfast/coder/encoder_v2/fast_encoder_core.cpp
@@ -17,7 +17,10 @@ void fast_encoder_core::encode_segment(const message_cref cref,
   template_instruction *instruction = std::get<0>(*info);
 
   if (force_reset || instruction->has_reset_attribute())
+  {
     repo_.reset_dictionary();
+    active_message_info_ = nullptr;
+  }
 
   bool need_encode_template_id = (active_message_info_ != info);
 


### PR DESCRIPTION
I need to encode and send template id.

I use fast_encoder_v2 with only one description parameter:
`encoder = new mfast::fast_encoder_v2(my_message::description());`

Constructor of fast_encoder_v2 calls init function, which sets active_message_info_ member variable.
In encode_segment method need_encode_template_id is set as follows:

`bool need_encode_template_id = (active_message_info_ != info);`

But if there is only one message type, active_message_info_ is always equal to info, so template id will never be encoded.

I suggest to reset active_message_info_ variable when method is called with force_reset flag = true. 
