### PR TITLE
Use absolute install path in separate variables (avoiding empty CPack archieve)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
 foreach (p IN ITEMS LIB BIN INCLUDE DATA CMAKE)
   set (var "INSTALL_${p}_DIR")
   if (NOT IS_ABSOLUTE "${${var}}")
-    set("${var}" "${CMAKE_INSTALL_PREFIX}/${${var}}")
+    set("ABSOLUTE_${var}" "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  else ()
+    set("ABSOLUTE_${var}" "${${var}}")
   endif ()
 endforeach (p)
 
@@ -244,7 +246,7 @@ configure_file(mFASTConfig.cmake.in
                @ONLY)
 
 # Create the mFASTConfig.cmake for the install tree
-file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")
+file(RELATIVE_PATH REL_INCLUDE_DIR "${ABSOLUTE_INSTALL_CMAKE_DIR}" "${ABSOLUTE_INSTALL_INCLUDE_DIR}")
 set(CONF_INCLUDE_DIRS "\${MFAST_CMAKE_DIR}/${REL_INCLUDE_DIR}")
 configure_file(mFASTConfig.cmake.in
                "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/mFASTConfig.cmake"


### PR DESCRIPTION
Currently when you run CPack (at least with CPACK_GENERATOR=TGZ) archive is empty because absolute paths are used to install.

Here code is rewritten to use relative paths to install's and absolute paths only when needed.

Hope didn't miss other places where full path is needed