### PR TITLE
Fix for issue #59 - Optional None Operator encoded incorrect.

### DIFF
--- a/src/mfast/coder/encoder/encoder_field_operator.cpp
+++ b/src/mfast/coder/encoder/encoder_field_operator.cpp
@@ -75,7 +75,14 @@ public:
   template <typename T>
   void encode_impl(const T &cref, fast_ostream &stream,
                    encoder_presence_map & /* pmap */) const {
-    stream << cref;
+      if (cref.absent()) 
+      {
+          stream.encode_null();
+      }
+      else
+      {
+          stream << cref;
+      }
 
     // Fast Specification 1.1, page 22
     //

--- a/src/mfast/coder/encoder/fast_encoder.cpp
+++ b/src/mfast/coder/encoder/fast_encoder.cpp
@@ -196,7 +196,7 @@ void fast_encoder_impl::visit(message_cref cref, bool force_reset) {
   aggregate_cref message(cref.field_storage(0), instruction);
 
   for (auto &&field : message)
-    if (field.present())
+    if (field.present() || field.instruction()->field_operator() == operator_none)
       apply_accessor(*this, field);
 
   pmap.commit();


### PR DESCRIPTION
There might be more unit test that should be added for the full visitor part of the code. But the new unit test added did not work with the base code.  

