### PR TITLE
Get rid of deprecated header (does not exist in the latest boost).

### DIFF
--- a/src/mfast/coder/encoder/encoder_presence_map.h
+++ b/src/mfast/coder/encoder/encoder_presence_map.h
@@ -9,7 +9,7 @@
 #include "fast_ostream.h"
 
 namespace mfast {
-#ifdef BOOST_BIG_ENDIAN
+#ifdef BOOST_ENDIAN_BIG_BYTE
 const int SMALLEST_ADDRESS_BYTE = sizeof(std::size_t) - 1;
 #else
 const int SMALLEST_ADDRESS_BYTE = 0;

--- a/src/mfast/coder/encoder/encoder_presence_map.h
+++ b/src/mfast/coder/encoder/encoder_presence_map.h
@@ -5,7 +5,7 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include "fast_ostream.h"
 
 namespace mfast {


### PR DESCRIPTION
**boost/detail/endian.hpp** has been deprecated since god knows when. It was removed from the latest version of boost. Use **boost/predef/other/endian.h** as documentation suggests.