### PR TITLE
Add check for boost version to set appropriate c++ standard.

### DIFF
--- a/cmake/SetCXXStandard.cmake
+++ b/cmake/SetCXXStandard.cmake
@@ -1,6 +1,11 @@
 
+find_package(Boost 1.56.0 REQUIRED)
+if(Boost_VERSION VERSION_LESS "1.72.0")
+	set(CMAKE_CXX_STANDARD 11 CACHE INTERNAL "specifies the C++ standard whose features are requested to build this target")
+else()
+	set(CMAKE_CXX_STANDARD 14 CACHE INTERNAL "specifies the C++ standard whose features are requested to build this target")
+endif()
 
-set(CMAKE_CXX_STANDARD 11 CACHE INTERNAL "specifies the C++ standard whose features are requested to build this target")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   ### Even though CMAKE_CXX_STANDARD_REQUIRED is supported since CMake 3.1, it doesn't work for Emscripten em++ together with

--- a/cmake/SetCXXStandard.cmake
+++ b/cmake/SetCXXStandard.cmake
@@ -10,5 +10,5 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   ### Even though CMAKE_CXX_STANDARD_REQUIRED is supported since CMake 3.1, it doesn't work for Emscripten em++ together with
   ### Cmake 3.6.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
 endif()


### PR DESCRIPTION
Also this solution is suboptimal, it solves compilation error for people with recent boost versions. Ideally would be setting appropriate target properties to cxx_std_11 using modern cmake approach.