### PR TITLE
Constant sequence length fix

### DIFF
--- a/src/mfast/ext_ref.h
+++ b/src/mfast/ext_ref.h
@@ -310,8 +310,12 @@ public:
   cref_type get() const { return base_; }
   is_optional_type optional() const { return is_optional_type(); }
   length_type set_length(value_storage &storage) const {
+    auto* length_inst = base_.instruction()->length_instruction();
     field_mref_base length_mref(nullptr, &storage,
-                                base_.instruction()->length_instruction());
+                                length_inst);
+    // a temporary storage is used for sequence length field
+    // and we must initialize it properly to support constant operators
+    length_inst->construct_value(storage, nullptr);
     return length_type(length_mref);
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ FASTTYPEGEN_TARGET(simple_types6 simple6.xml)
 FASTTYPEGEN_TARGET(simple_types7 simple7.xml)
 FASTTYPEGEN_TARGET(simple_types8 simple8.xml)
 FASTTYPEGEN_TARGET(simple_types9 simple9.xml)
+FASTTYPEGEN_TARGET(simple_types10 simple10.xml)
 
 
 FASTTYPEGEN_TARGET(test_types1 test1.xml test2.xml)
@@ -51,6 +52,7 @@ add_executable (mfast_test
                 ${FASTTYPEGEN_simple_types7_OUTPUTS}
                 ${FASTTYPEGEN_simple_types8_OUTPUTS}
                 ${FASTTYPEGEN_simple_types9_OUTPUTS}
+                ${FASTTYPEGEN_simple_types10_OUTPUTS}
                 fast_type_gen_test.cpp
                 dictionary_builder_test.cpp
                 json_test.cpp

--- a/tests/simple10.xml
+++ b/tests/simple10.xml
@@ -1,0 +1,14 @@
+<?xml version=" 1.0 "?>
+<templates xmlns="http://www.fixprotocol.org/ns/template-definition"
+ templateNs="http://www.fixprotocol.org/ns/templates/sample" ns="http://www.fixprotocol.org/ns/fix">
+<template name="Test" id="1">
+  <sequence name="sequence1">
+    <length id="110">
+      <constant value="1"/>
+    </length>
+    <int64 name="field1" id="111">
+      <copy/>
+    </int64>
+  </sequence>
+</template>
+</templates>


### PR DESCRIPTION
This fixes error which occurs when parsing Eurex messages with mFAST.

Eurex schema uses constant length sequences in several places, e.g. in QuoteRequest message:
```
  <sequence name="SequenceGroup">
      <length name="NoElements" id="111">
        <constant value="1"/>
      </length>
      <int64 name="Id" id="112">
        <copy/>
      </int64>
    </sequence>
```
Unfortunately mFAST fails to properly handle that schema.

The problem boils down to code decoding sequence instruction:
```
    template <typename T>
    inline void fast_decoder_base::decode_field(const T &ext_ref,
                                                sequence_type_tag) {
      value_storage storage;

      auto length = ext_ref.set_length(storage);
      this->visit(length);
```

Here value_storage is not initialized with initial (constant) value. Later, in
```
    template <typename T, typename TypeCategory>
    void fast_decoder_base::decode_field(const T &ext_ref,
                                         constant_operator_tag,
                                         TypeCategory) {
```
the value for constant field is not copied (and that's what was changed
in original patch) and sequence length is considered to be 0 leaving all
of sequence payload bytes unparsed.