### PR TITLE
00 by encoding

### DIFF
--- a/src/mfast/coder/encoder/fast_encoder.cpp
+++ b/src/mfast/coder/encoder/fast_encoder.cpp
@@ -189,7 +189,7 @@ void fast_encoder_impl::visit(message_cref cref, bool force_reset) {
 
   if (need_encode_template_id) {
     active_message_id_ = template_id;
-    strm_.encode(active_message_id_, false, false);
+    strm_.encode(template_id, false, false);
   }
 
   aggregate_cref message(cref.field_storage(0), instruction);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ FASTTYPEGEN_TARGET(simple_types7 simple7.xml)
 FASTTYPEGEN_TARGET(simple_types8 simple8.xml)
 FASTTYPEGEN_TARGET(simple_types9 simple9.xml)
 FASTTYPEGEN_TARGET(simple_types10 simple10.xml)
+FASTTYPEGEN_TARGET(simple_types11 simple11.xml)
 
 
 FASTTYPEGEN_TARGET(test_types1 test1.xml test2.xml)
@@ -35,6 +36,7 @@ add_executable (mfast_test
                 fast_ostream_test.cpp
                 decoder_operator_test.cpp
                 encoder_operator_test.cpp
+                encoder_test.cpp
                 field_comparator_test.cpp
                 coder_test.cpp
                 value_storage_test.cpp
@@ -53,6 +55,7 @@ add_executable (mfast_test
                 ${FASTTYPEGEN_simple_types8_OUTPUTS}
                 ${FASTTYPEGEN_simple_types9_OUTPUTS}
                 ${FASTTYPEGEN_simple_types10_OUTPUTS}
+                ${FASTTYPEGEN_simple_types11_OUTPUTS}
                 fast_type_gen_test.cpp
                 dictionary_builder_test.cpp
                 json_test.cpp

--- a/tests/encoder_test.cpp
+++ b/tests/encoder_test.cpp
@@ -1,0 +1,29 @@
+#include "catch.hpp"
+#include <mfast.h>
+#include <mfast/coder/fast_encoder.h>
+#include <cstring>
+#include <stdexcept>
+
+#include "simple11.h"
+#include "byte_stream.h"
+
+TEST_CASE("test simple encoder","[test_encoder]")
+{
+    mfast::fast_encoder encoder_;
+    encoder_.include({simple11::description()});
+
+    const int buffer_size = 128;
+    char buffer[buffer_size];
+
+    simple11::Test_1 msg;
+    simple11::Test_1_mref msg_ref = msg.mref();
+
+    msg_ref.set_field1().as(1);
+    msg_ref.set_field2().as(2);
+    msg_ref.set_field3().as(3);
+
+    std::size_t encoded_size = encoder_.encode(msg_ref, buffer, buffer_size);
+
+    byte_stream result("\xF8\x81\x81\x82\x83");
+    CHECK(result == byte_stream(buffer, encoded_size));
+}

--- a/tests/simple11.xml
+++ b/tests/simple11.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<templates xmlns="http://www.fixprotocol.org/ns/template-definition"
+    templateNs="http://www.fixprotocol.org/ns/templates/sample"
+    ns="http://www.fixprotocol.org/ns/fix">
+  <template name="Test_1" id="1">
+    <uInt32 name="field1" id="11"><copy/></uInt32>
+    <uInt32 name="field2" id="12"><copy/></uInt32>
+    <uInt32 name="field3" id="13"><copy/></uInt32>
+  </template>
+  <template name="Test_2" id="2">
+    <uInt32 name="field4" id="21"><copy/></uInt32>
+    <uInt32 name="field5" id="22"><copy/></uInt32>
+    <uInt32 name="field6" id="23"><copy/></uInt32>
+  </template>  
+</templates>


### PR DESCRIPTION
In the case of the encoder: If you use the active_message_id_, which data type, which is _int64_t_ - for the template type Id -.  It will generate an:

`0x00 0xTemplateId`

In the FAST stream, in this case it is necessary to send the Template Id without the 0x00 and this is done in the library with a unsigned type. That is why, you have to use the template_id to encode in the function.