### PR TITLE
Correct Pmap calculation for the template id and group types

### DIFF
--- a/src/mfast/instructions/field_instruction.h
+++ b/src/mfast/instructions/field_instruction.h
@@ -165,7 +165,8 @@ protected:
   virtual void update_invariant() {
     nullable_flag_ = optional_flag_ && (operator_id_ != operator_constant);
     has_pmap_bit_ = operator_id_ > operator_delta ||
-                    ((operator_id_ == operator_constant) && optional_flag_);
+                    ((operator_id_ == operator_constant) && optional_flag_)||
+                    (field_type_ == field_type_group && optional_flag_);
   }
 
   // uint16_t field_index_;
@@ -208,7 +209,8 @@ inline field_instruction::field_instruction(operator_enum_t operator_id,
       optional_flag_(optional),
       nullable_flag_(optional && (operator_id != operator_constant)),
       has_pmap_bit_(operator_id > operator_delta ||
-                    ((operator_id == operator_constant) && optional)),
+                    ((operator_id == operator_constant) && optional) ||
+                    (field_type == field_type_group && optional)),
       has_initial_value_(false), field_type_(field_type),
       previous_value_shared_(false), id_(id), name_(name), ns_(ns),
       tag_(std::move(tag)) {}

--- a/src/mfast/instructions/template_instruction.h
+++ b/src/mfast/instructions/template_instruction.h
@@ -22,6 +22,7 @@ public:
                                 cpp_ns, tag),
         template_ns_(template_ns), reset_(reset) {
     field_type_ = field_type_template;
+    segment_pmap_size_++;   // Add one to the template id bit
   }
 
   const char *template_ns() const { return template_ns_; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable (mfast_test
                 aggregate_view_test.cpp
                 simple_coder_test.cpp
                 scp_reset_test.cpp
+                message_pmap_test.cpp
             )
 
 target_link_libraries (mfast_test

--- a/tests/message_pmap_test.cpp
+++ b/tests/message_pmap_test.cpp
@@ -1,0 +1,29 @@
+#include "catch.hpp"
+#include <mfast.h>
+
+#include "simple1.h"
+#include "simple2.h"
+
+TEST_CASE("test message pmap message number of bits of a field message content","[message_pmap_number_bits_field]")
+{
+    simple1::Test msg;
+    simple1::Test_mref msg_ref = msg.mref();
+
+    msg_ref.set_field1().as(1);
+    msg_ref.set_field2().as(2);
+    msg_ref.set_field3().as(3);
+
+    CHECK(msg.instruction()->segment_pmap_size() == 4);
+}
+
+TEST_CASE("test message pmap message number of bits of a field and group message content","[message_pmap_number_bits_group]")
+{
+    simple2::Test msg;
+    simple2::Test_mref msg_ref = msg.mref();
+
+    msg_ref.set_field1().as(1);
+    msg_ref.set_group1().set_field2().as(2);
+    msg_ref.set_group1().set_field3().as(3);
+
+    CHECK(msg.instruction()->segment_pmap_size() == 3);
+}


### PR DESCRIPTION
Correct the pmap calculation for the case of the template and group.

In the case of the template, there is necessary to add one bit. And in the case of the optional group, there is necessary to add also a bit.