### PR TITLE
Default optional

### DIFF
--- a/src/mfast/coder/encoder_v2/fast_encoder_core.h
+++ b/src/mfast/coder/encoder_v2/fast_encoder_core.h
@@ -470,6 +470,11 @@ void fast_encoder_core::encode_field(const T &ext_ref, default_operator_tag,
     return;
   }
 
+  if (ext_ref.optional() && !ext_ref.present()) {
+    pmap.set_next_bit(false);
+    return;
+  }
+
   pmap.set_next_bit(true);
   if (!ext_ref.present()) {
     //  A NULL indicates that the value is absent and the state of the previous

--- a/tests/encoder_decoder_test.cpp
+++ b/tests/encoder_decoder_test.cpp
@@ -225,3 +225,23 @@ TEST_CASE("simple field group optional encoder/decoder","[field_group_optional_e
         REQUIRE(test_case.decoding("\xF0\x85\x82\xC0\x81\x81\x82\x8B",test_5.cref(),true));
     }
 }
+
+TEST_CASE("simple optional field with default value encoder/decoder","[optional_field_with_default_value_encoder_decoder]")
+{
+    fast_test_coding_case<simple12::templates_description> test_case;
+
+    SECTION("encode fields")
+    {
+        simple12::Test_6 test_6;
+        simple12::Test_6_mref test_6_mref = test_6.mref();
+        test_6_mref.set_field_6_2().as(1);
+        // \xD0 : 1110 : OK
+        // 1 : Stop Bit.
+        // 1 : Set Template Id.
+        // 0 : Not Set Field field_6_1
+        // 1 : Set field_6_2
+        REQUIRE(test_case.encoding(test_6.cref(),"\xD0\x86\x82",true));
+        test_6_mref.set_field_6_1().as(1);
+        REQUIRE(test_case.decoding("\xD0\x86\x82",test_6.cref(),true));
+    }
+}

--- a/tests/encoder_decoder_test_v2.cpp
+++ b/tests/encoder_decoder_test_v2.cpp
@@ -226,3 +226,23 @@ TEST_CASE("simple field group optional encoder_v2/decoder_v2","[field_group_opti
         REQUIRE(test_case.decoding("\xF0\x85\x82\xC0\x81\x81\x82\x8B",test_5.cref(),true));
     }
 }
+
+TEST_CASE("simple optional field with default value encoder_v2/decoder_v2","[optional_field_with_default_value_encoder_v2/decoder_v2]")
+{
+    fast_test_coding_case_v2<simple12::templates_description> test_case;
+
+    SECTION("encode field")
+    {
+        simple12::Test_6 test_6;
+        simple12::Test_6_mref test_6_mref = test_6.mref();
+        test_6_mref.set_field_6_2().as(1);
+        // \xD0 : 1110 : OK
+        // 1 : Stop Bit.
+        // 1 : Set Template Id.
+        // 0 : Not Set Field field_6_1
+        // 1 : Set field_6_2
+        REQUIRE(test_case.encoding(test_6.cref(),"\xD0\x86\x82",true));
+        test_6_mref.set_field_6_1().as(1);
+        REQUIRE(test_case.decoding("\xD0\x86\x82",test_6.cref(),true));
+    }
+}

--- a/tests/encoder_operator_test.cpp
+++ b/tests/encoder_operator_test.cpp
@@ -405,7 +405,7 @@ TEST_CASE("test the encoding of fast operator default","[operator_default_encode
 
     inst.prev_value().defined(false); // reset the previous value to undefined again
 
-    REQUIRE( encode_ext_cref("\xC0\x80",
+    REQUIRE( encode_ext_cref("\x80",
                                  ext_cref<uint64_cref, default_operator_tag, optional_with_initial_value_tag>(result),
                                  PRESERVE_PREVIOUS_VALUE, &allocator ) );
   }

--- a/tests/simple12.xml
+++ b/tests/simple12.xml
@@ -32,4 +32,15 @@
             <uInt32 name="field_5_5" id="54" presence="optional"><copy/></uInt32>
         </group>
     </template>
+    <template name="Test_6" id="6">
+        <uInt32 name="field_6_1" id="61" presence="optional">
+            <default value="1"/>
+        </uInt32>
+        <uInt32 name="field_6_2" id="62" presence="optional">
+            <copy/>
+        </uInt32>
+        <uInt32 name="field_6_3" id="63">
+            <default value="1"/>
+        </uInt32>
+    </template>
 </templates>


### PR DESCRIPTION
For the case of default optional, if the value storage is empty, it has not send anything in the steam.

This is correct done in the V! but not in the V2.