### PR TITLE
Optional group inside sequence

### DIFF
--- a/src/fast_type_gen/inl_gen.cpp
+++ b/src/fast_type_gen/inl_gen.cpp
@@ -681,8 +681,16 @@ void inl_gen::visit(const mfast::sequence_field_instruction *inst,
     for (std::size_t i = 0; i < inst->subinstructions().size(); ++i) {
       const field_instruction *subinst = inst->subinstructions()[i];
 
-      out_ << "  visitor.visit(" << get_ext_cref_type(subinst) << " ((*this)["
-           << i << "]) );\n";
+      if (is_group_type(subinst) && subinst->optional())
+      {
+        out_ << "  {\n"
+            << "    " << get_ext_cref_type(subinst) << " ext_cref_group((*this)[" << i << "]);\n"
+            << "    ext_cref_group.set_group_present(this->field_storage(" << i << ")->is_present());\n"
+            << "    visitor.visit(ext_cref_group);\n"
+            << "  }\n";
+      }
+      else
+        out_ << "  visitor.visit(" << get_ext_cref_type(subinst) << " ((*this)[" << i << "]) );\n";
     }
 
     out_ << "}\n\n";

--- a/src/mfast/ext_ref.h
+++ b/src/mfast/ext_ref.h
@@ -205,13 +205,13 @@ public:
   explicit ext_cref(const field_cref &base) : base_(base) {}
   explicit ext_cref(const aggregate_cref &base) : base_(base) {}
   cref_type get() const { return base_; }
-  bool present() const { return !this->optional() || group_present_; }
+  bool present() const { return group_present_; }
 
   void set_group_present(bool present) { group_present_ = present; }
 
 private:
   cref_type base_;
-  bool group_present_ = true;
+  bool group_present_ = this->optional()?false:true;
 };
 
 template <typename Properties>

--- a/tests/fast_test_coding_case_v2.hpp
+++ b/tests/fast_test_coding_case_v2.hpp
@@ -18,8 +18,7 @@ class fast_test_coding_case_v2
             decoder_v2_(DESC::instance())
         {}
 
-        bool
-        encoding(const mfast::message_cref& msg_ref, const byte_stream& result, bool reset=false)
+        bool encoding(const mfast::message_cref& msg_ref, const byte_stream& result, bool reset=false)
         {
             const int buffer_size = 128;
             char buffer[buffer_size];
@@ -32,8 +31,7 @@ class fast_test_coding_case_v2
             return false;
         }
 
-        bool
-        decoding(const byte_stream& bytes, const mfast::message_cref& result, bool reset=false)
+        bool decoding(const byte_stream& bytes, const mfast::message_cref& result, bool reset=false)
         {
           const char* first = bytes.data();
           mfast::message_cref msg = decoder_v2_.decode(first, first+bytes.size(), reset);

--- a/tests/sequence_encoder_decoder.cpp
+++ b/tests/sequence_encoder_decoder.cpp
@@ -237,3 +237,41 @@ TEST_CASE("group sequence inside sequence encoder/decoder","[group_sequence_insi
         REQUIRE(test_case.decoding("\xC0\x86\x81\xD0\xB2\x82\xB2",test_6.cref(),true));
     }
 }
+
+TEST_CASE("sequence with optional group encoder/decoder","[sequence_optional_group_encoder_decoder]")
+{
+    fast_test_coding_case<simple14::templates_description> test_case;
+
+    SECTION("group not present")
+    {
+        simple14::Test_7 test_7;
+        simple14::Test_7_mref test_7_mref = test_7.mref();
+
+        auto sequence_7_mref = test_7_mref.set_sequence_7();
+        sequence_7_mref.resize(1);
+
+        auto element_sequence = sequence_7_mref.front();
+        element_sequence.set_field_7_3().as(50);
+
+        REQUIRE(test_case.encoding(test_7.cref(),"\xC0\x87\x81\xC0\xB2",true));
+        REQUIRE(test_case.decoding("\xC0\x87\x81\xC0\xB2",test_7.cref(),true));
+    }
+
+    SECTION("group present")
+    {
+        simple14::Test_7 test_7;
+        simple14::Test_7_mref test_7_mref = test_7.mref();
+
+        auto sequence_7_mref = test_7_mref.set_sequence_7();
+        sequence_7_mref.resize(1);
+
+        auto element_sequence = sequence_7_mref.front();
+        element_sequence.set_field_7_3().as(50);
+
+        auto group_7 = element_sequence.set_group_7();
+        group_7.set_field_7_4().as(20);
+
+        REQUIRE(test_case.encoding(test_7.cref(),"\xC0\x87\x81\xE0\xB2\x94",true));
+        REQUIRE(test_case.decoding("\xC0\x87\x81\xE0\xB2\x94",test_7.cref(),true));
+    }
+}

--- a/tests/sequence_encoder_decoder_v2.cpp
+++ b/tests/sequence_encoder_decoder_v2.cpp
@@ -239,3 +239,41 @@ TEST_CASE("group sequence inside sequence encoder_V2/decoder_v2","[group_sequenc
         REQUIRE(test_case.decoding("\xC0\x86\x81\xD0\xB2\x82\xB2",test_6.cref(),true));
     }
 }
+
+TEST_CASE("sequence with optional group encoder_V2/decoder_v2","[sequence_optional_group_encoder_v2_decoder_v2]")
+{
+    fast_test_coding_case_v2<simple14::templates_description> test_case;
+
+    SECTION("group not present")
+    {
+        simple14::Test_7 test_7;
+        simple14::Test_7_mref test_7_mref = test_7.mref();
+
+        auto sequence_7_mref = test_7_mref.set_sequence_7();
+        sequence_7_mref.resize(1);
+
+        auto element_sequence = sequence_7_mref.front();
+        element_sequence.set_field_7_3().as(50);
+
+        REQUIRE(test_case.encoding(test_7.cref(),"\xC0\x87\x81\xC0\xB2",true));
+        REQUIRE(test_case.decoding("\xC0\x87\x81\xC0\xB2",test_7.cref(),true));
+    }
+
+    SECTION("group present")
+    {
+        simple14::Test_7 test_7;
+        simple14::Test_7_mref test_7_mref = test_7.mref();
+
+        auto sequence_7_mref = test_7_mref.set_sequence_7();
+        sequence_7_mref.resize(1);
+
+        auto element_sequence = sequence_7_mref.front();
+        element_sequence.set_field_7_3().as(50);
+
+        auto group_7 = element_sequence.set_group_7();
+        group_7.set_field_7_4().as(20);
+
+        REQUIRE(test_case.encoding(test_7.cref(),"\xC0\x87\x81\xE0\xB2\x94",true));
+        REQUIRE(test_case.decoding("\xC0\x87\x81\xE0\xB2\x94",test_7.cref(),true));
+    }
+}

--- a/tests/simple14.xml
+++ b/tests/simple14.xml
@@ -54,4 +54,13 @@
             </sequence>
         </group>
     </template>
+    <template name="Test_7" id="7">
+        <sequence name="sequence_7">
+            <length name="field_7_2" id="72"></length>
+            <uInt32 name="field_7_3" id="73"><copy/></uInt32>
+            <group name="group_7" presence="optional">
+                <uInt32 name="field_7_4" id="74"/>
+            </group>
+        </sequence>
+    </template>
 </templates>


### PR DESCRIPTION
Correct the case of the optional group inside a sequence. Before the correction, there is a different result depending the decoder.