### PR TITLE
ODR fixes

### DIFF
--- a/src/mfast/allocator.cpp
+++ b/src/mfast/allocator.cpp
@@ -5,14 +5,10 @@
 // See the file license.txt for licensing information.
 #include "allocator.h"
 #include <new>
+#include "allocator_utils.h"
 #include <cstring>
 
 namespace mfast {
-
-inline std::size_t align(std::size_t n, std::size_t x) {
-  const std::size_t y = x - 1;
-  return (n + y) & ~y;
-}
 
 std::size_t allocator::reallocate(void *&pointer, std::size_t old_size,
                                   std::size_t new_size) {

--- a/src/mfast/allocator_utils.h
+++ b/src/mfast/allocator_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstddef>
+
+namespace mfast {
+
+inline std::size_t align(std::size_t n, std::size_t x) {
+  const std::size_t y = x - 1;
+  return (n + y) & ~y;
+}
+
+}

--- a/src/mfast/arena_allocator.cpp
+++ b/src/mfast/arena_allocator.cpp
@@ -4,16 +4,12 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "arena_allocator.h"
+#include "allocator_utils.h"
 #include <cstring>
 #include <algorithm>
 #include <cstdlib>
 
 namespace mfast {
-
-inline std::size_t align(std::size_t n, std::size_t x) {
-  const std::size_t y = x - 1;
-  return (n + y) & ~y;
-}
 
 void arena_allocator::free_list(memory_chunk_base *head) {
   memory_chunk_base *tmp;

--- a/src/mfast/xml_parser/FastXMLVisitor.cpp
+++ b/src/mfast/xml_parser/FastXMLVisitor.cpp
@@ -4,17 +4,14 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "FastXMLVisitor.h"
+#include "xml_util.h"
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
 const char *FastXMLVisitor::get_optional_attr(const XMLElement &element,
                                               const char *attr_name,
                                               const char *default_value) const {
-  const XMLAttribute *attr = element.FindAttribute(attr_name);
-  if (attr == nullptr) {
-    return default_value;
-  }
-  return attr->Value();
+  return mfast::xml_parser::get_optional_attr(element, attr_name, default_value);
 }
 
 bool FastXMLVisitor::is_mandatory_constant(const XMLElement &element) {

--- a/src/mfast/xml_parser/view_info_builder.cpp
+++ b/src/mfast/xml_parser/view_info_builder.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <string.h>
 #include "view_info_builder.h"
+#include "xml_util.h"
 #include "../exceptions.h"
 #include <algorithm>
 namespace mfast {
@@ -157,16 +158,6 @@ void view_info_builder::visit(const set_field_instruction *inst,
 
 struct tag_reference_name;
 typedef boost::error_info<tag_reference_name, std::string> reference_name_info;
-
-inline const char *get_optional_attr(const tinyxml2::XMLElement &element,
-                                     const char *attr_name,
-                                     const char *default_value) {
-  const tinyxml2::XMLAttribute *attr = element.FindAttribute(attr_name);
-  if (attr == nullptr) {
-    return default_value;
-  }
-  return attr->Value();
-}
 
 void view_info_builder::build_field_view(const tinyxml2::XMLElement &element,
                                          unsigned &max_depth,

--- a/src/mfast/xml_parser/xml_util.h
+++ b/src/mfast/xml_parser/xml_util.h
@@ -15,10 +15,7 @@ inline const char *get_optional_attr(const XMLElement &element,
                                      const char *attr_name,
                                      const char *default_value) {
   const XMLAttribute *attr = element.FindAttribute(attr_name);
-  if (attr == nullptr) {
-    return default_value;
-  }
-  return attr->Value();
+  return attr ? attr->Value() : default_value;
 }
 
 inline const char *string_dup(const char *str, arena_allocator &alloc) {


### PR DESCRIPTION
When trying to compile the library using CMake unity builds, the compiler errors out due to multiple duplicated function definitions.

This PR removes duplicated code to allow for unity builds to succeed by adhering to the one-definition-rule.

You can try this out with:
```
$ cmake -B build -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_PACKAGES=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=100 -DCMAKE_CXX_FLAGS="-DBOOST_NO_CXX11_EXTERN_TEMPLATE"
...
$ cmake --build build
```
Prior to these changes, the build will break.