### PR TITLE
Cleanup include usage

### DIFF
--- a/src/fast_type_gen/fast_type_gen.cpp
+++ b/src/fast_type_gen/fast_type_gen.cpp
@@ -9,7 +9,6 @@
 #include "hpp_gen.h"
 #include "inl_gen.h"
 #include "cpp_gen.h"
-#include "mfast/coder/common/dictionary_builder.h"
 #include "mfast/coder/common/template_repo.h"
 
 #include <stdlib.h>

--- a/src/fast_type_gen/indented_ostream.h
+++ b/src/fast_type_gen/indented_ostream.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <ostream>
 #include <iomanip>
 #include <sstream>
 struct indent_t {};

--- a/src/mfast/allocator.cpp
+++ b/src/mfast/allocator.cpp
@@ -4,7 +4,6 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "allocator.h"
-#include <new>
 #include "allocator_utils.h"
 #include <cstring>
 

--- a/src/mfast/allocator.h
+++ b/src/mfast/allocator.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstddef>
-#include <algorithm>
 #include "mfast/mfast_export.h"
 namespace mfast {
 /// An abstract interface for allocators.

--- a/src/mfast/arena_allocator.cpp
+++ b/src/mfast/arena_allocator.cpp
@@ -6,8 +6,8 @@
 #include "arena_allocator.h"
 #include "allocator_utils.h"
 #include <cstring>
-#include <algorithm>
 #include <cstdlib>
+#include <new>
 
 namespace mfast {
 

--- a/src/mfast/arena_allocator.h
+++ b/src/mfast/arena_allocator.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <new>
 #include <stdint.h>
 #include <cassert>
 #include <cstddef>

--- a/src/mfast/coder/common/codec_helper.h
+++ b/src/mfast/coder/common/codec_helper.h
@@ -7,7 +7,6 @@
 
 #include "../../string_ref.h"
 #include "../../exceptions.h"
-#include <stdexcept>
 
 namespace mfast {
 namespace detail {

--- a/src/mfast/coder/common/debug_stream.h
+++ b/src/mfast/coder/common/debug_stream.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <iostream>
-#include "../../output.h"
 #ifdef NDEBUG
 
 struct debug_stream {
@@ -25,6 +24,7 @@ struct debug_stream {
 };
 
 #else
+#include "../../output.h"
 
 class debug_stream {
 private:

--- a/src/mfast/coder/common/dictionary_builder.cpp
+++ b/src/mfast/coder/common/dictionary_builder.cpp
@@ -6,9 +6,6 @@
 #include "exceptions.h"
 #include "template_repo.h"
 #include <cstring>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
 
 namespace mfast {
 

--- a/src/mfast/coder/common/dictionary_builder.h
+++ b/src/mfast/coder/common/dictionary_builder.h
@@ -9,10 +9,10 @@
 #include "../mfast_coder_export.h"
 #include "../../field_instructions.h"
 #include "../../arena_allocator.h"
+#include "../../instructions/templates_description.h"
 #include <vector>
 #include <map>
 #include <string>
-#include <stdexcept>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4251) // non dll-interface class used as a member for

--- a/src/mfast/coder/decoder/decoder_field_operator.cpp
+++ b/src/mfast/coder/decoder/decoder_field_operator.cpp
@@ -3,7 +3,6 @@
 //
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
-#include "../mfast_coder_export.h"
 #include "../common/codec_helper.h"
 #include "fast_istream.h"
 #include "decoder_presence_map.h"

--- a/src/mfast/coder/decoder/fast_decoder.cpp
+++ b/src/mfast/coder/decoder/fast_decoder.cpp
@@ -4,17 +4,13 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include <boost/container/map.hpp>
-#include "../mfast_coder_export.h"
 #include "../fast_decoder.h"
 #include "../../field_visitor.h"
 #include "../../sequence_ref.h"
-#include "../../malloc_allocator.h"
-#include "../../output.h"
 #include "../../composite_type.h"
 #include "../common/exceptions.h"
 #include "../common/debug_stream.h"
 #include "../common/template_repo.h"
-#include "../common/codec_helper.h"
 #include "decoder_presence_map.h"
 #include "decoder_field_operator.h"
 #include "fast_istream.h"

--- a/src/mfast/coder/decoder/fast_istreambuf.h
+++ b/src/mfast/coder/decoder/fast_istreambuf.h
@@ -5,10 +5,7 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <stdexcept>
-
 #include "../../exceptions.h"
-#include <iostream>
 
 namespace mfast {
 class fast_istream;

--- a/src/mfast/coder/decoder_v2/fast_decoder_core.h
+++ b/src/mfast/coder/decoder_v2/fast_decoder_core.h
@@ -7,20 +7,16 @@
 
 #include "../mfast_coder_export.h"
 
-#include "../../sequence_ref.h"
+#include "../../ext_ref.h"
 #include "../../nested_message_ref.h"
-#include "../../malloc_allocator.h"
-#include "../../output.h"
 #include "../../composite_type.h"
 #include "../common/exceptions.h"
-#include "../common/debug_stream.h"
 #include "../common/template_repo.h"
 #include "../common/codec_helper.h"
 #include "../decoder/decoder_presence_map.h"
 #include "../common/codec_helper.h"
 #include "../decoder/fast_istream.h"
 #include "fast_istream_extractor.h"
-#include <tuple>
 #include <vector>
 namespace mfast {
 namespace coder {

--- a/src/mfast/coder/encoder/encoder_field_operator.cpp
+++ b/src/mfast/coder/encoder/encoder_field_operator.cpp
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #include <iterator>
 #include <algorithm>
-#include "../mfast_coder_export.h"
 #include "../common/codec_helper.h"
 #include "fast_ostream.h"
 #include "encoder_presence_map.h"

--- a/src/mfast/coder/encoder/fast_encoder.cpp
+++ b/src/mfast/coder/encoder/fast_encoder.cpp
@@ -3,14 +3,11 @@
 //
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
-#include "../mfast_coder_export.h"
 #include "../../field_visitor.h"
 #include "../../sequence_ref.h"
-#include "../../malloc_allocator.h"
 #include "../fast_encoder.h"
 #include "../common/template_repo.h"
 #include "../common/exceptions.h"
-#include "../../output.h"
 #include "encoder_presence_map.h"
 #include "encoder_field_operator.h"
 #include "fast_ostream.h"

--- a/src/mfast/coder/encoder/fast_ostream.h
+++ b/src/mfast/coder/encoder/fast_ostream.h
@@ -5,9 +5,9 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "../../field_instructions.h"
 #include "../common/codec_helper.h"
 #include "fast_ostreambuf.h"
+#include <limits>
 
 namespace mfast {
 class encoder_presence_map;

--- a/src/mfast/coder/encoder/fast_ostreambuf.cpp
+++ b/src/mfast/coder/encoder/fast_ostreambuf.cpp
@@ -3,8 +3,9 @@
 //
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
-#include <cstring>
 #include <algorithm>
+#include <cassert>
+#include <cstring>
 #include "fast_ostreambuf.h"
 
 namespace mfast {

--- a/src/mfast/coder/encoder/fast_ostreambuf.h
+++ b/src/mfast/coder/encoder/fast_ostreambuf.h
@@ -7,7 +7,7 @@
 
 #include <stdexcept>
 #include "../mfast_coder_export.h"
-#include "../../exceptions.h"
+#include <boost/exception/all.hpp>
 
 namespace mfast {
 class buffer_overflow_error : public virtual boost::exception,

--- a/src/mfast/coder/encoder_v2/fast_encoder_core.cpp
+++ b/src/mfast/coder/encoder_v2/fast_encoder_core.cpp
@@ -1,4 +1,5 @@
 #include "fast_encoder_core.h"
+#include "../common/exceptions.h"
 
 namespace mfast {
 namespace coder {

--- a/src/mfast/coder/encoder_v2/fast_encoder_core.h
+++ b/src/mfast/coder/encoder_v2/fast_encoder_core.h
@@ -1,12 +1,9 @@
 #pragma once
 
 #include "../mfast_coder_export.h"
-#include "../../sequence_ref.h"
 #include "../../enum_ref.h"
 #include "../../nested_message_ref.h"
-#include "../../malloc_allocator.h"
 #include "../common/template_repo.h"
-#include "../common/exceptions.h"
 #include "../encoder/fast_ostream.h"
 #include "../encoder/resizable_fast_ostreambuf.h"
 #include "../encoder/encoder_presence_map.h"

--- a/src/mfast/coder/encoder_v2/fast_ostream_inserter.h
+++ b/src/mfast/coder/encoder_v2/fast_ostream_inserter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../../int_ref.h"
 #include "../../string_ref.h"
 #include "../../decimal_ref.h"
 #include "../../ext_ref.h"

--- a/src/mfast/coder/fast_decoder.h
+++ b/src/mfast/coder/fast_decoder.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "mfast_coder_export.h"
+#include "../instructions/templates_description.h"
 #include "../message_ref.h"
 #include "../malloc_allocator.h"
 #include <initializer_list>

--- a/src/mfast/coder/fast_decoder_v2.h
+++ b/src/mfast/coder/fast_decoder_v2.h
@@ -7,7 +7,6 @@
 
 #include "decoder_v2/fast_decoder_core.h"
 #include <type_traits>
-#include <tuple>
 
 template <typename... CONDITIONS> struct all_true;
 

--- a/src/mfast/coder/fast_encoder.h
+++ b/src/mfast/coder/fast_encoder.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "mfast_coder_export.h"
+#include "../instructions/templates_description.h"
 #include "../message_ref.h"
 #include "../malloc_allocator.h"
 

--- a/src/mfast/coder/fast_encoder_v2.h
+++ b/src/mfast/coder/fast_encoder_v2.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <vector>
-#include <tuple>
 #include "encoder_v2/fast_encoder_core.h"
 
 namespace mfast {

--- a/src/mfast/decimal_ref.cpp
+++ b/src/mfast/decimal_ref.cpp
@@ -3,11 +3,6 @@
 //
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
-#include <cmath>
-#include <cfloat>
-
-#include <iostream>
-
 #include <boost/multiprecision/number.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
 

--- a/src/mfast/decimal_ref.h
+++ b/src/mfast/decimal_ref.h
@@ -5,8 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <cmath>
-#include <cfloat>
 #include <boost/utility/string_ref.hpp>
 #include "mfast_export.h"
 #include "field_ref.h"

--- a/src/mfast/enum_ref.h
+++ b/src/mfast/enum_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "mfast/field_instructions.h"
 #include "mfast/field_ref.h"
 #include "mfast/type_category.h"
 

--- a/src/mfast/field_comparator.h
+++ b/src/mfast/field_comparator.h
@@ -4,7 +4,6 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #pragma once
-#include <utility>
 #include "field_visitor.h"
 namespace mfast {
 namespace detail {

--- a/src/mfast/field_ref.h
+++ b/src/mfast/field_ref.h
@@ -6,10 +6,8 @@
 #pragma once
 
 #include "field_instructions.h"
-#include <new>
-#include <iostream>
+#include "mfast_export.h"
 #include <typeinfo>
-#include <type_traits>
 #include <boost/config.hpp>
 #include <boost/exception/all.hpp>
 

--- a/src/mfast/field_visitor.h
+++ b/src/mfast/field_visitor.h
@@ -11,7 +11,6 @@
 #include "string_ref.h"
 #include "group_ref.h"
 #include "sequence_ref.h"
-#include "message_ref.h"
 #include "nested_message_ref.h"
 #include "set_ref.h"
 

--- a/src/mfast/group_ref.h
+++ b/src/mfast/group_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "field_instructions.h"
 #include "field_ref.h"
 #include "field_mref.h"
 #include "aggregate_ref.h"

--- a/src/mfast/instructions/decimal_instruction.cpp
+++ b/src/mfast/instructions/decimal_instruction.cpp
@@ -4,7 +4,7 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 
-#include "../field_instructions.h"
+#include "decimal_instruction.h"
 
 namespace mfast {
 void decimal_field_instruction::construct_value(value_storage &storage,

--- a/src/mfast/instructions/field_instruction.h
+++ b/src/mfast/instructions/field_instruction.h
@@ -12,7 +12,6 @@
 #include "mfast/mfast_export.h"
 #include "mfast/arena_allocator.h"
 #include "mfast/allocator.h"
-#include <algorithm>
 #include <iostream>
 
 namespace mfast {

--- a/src/mfast/int_ref.h
+++ b/src/mfast/int_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "field_instructions.h"
 #include "field_ref.h"
 #include "type_category.h"
 

--- a/src/mfast/json/json.h
+++ b/src/mfast/json/json.h
@@ -8,7 +8,8 @@
 #define MFAST_JSON_H
 
 #include "mfast_json_export.h"
-#include "../../mfast.h"
+#include "../aggregate_ref.h"
+#include "../sequence_ref.h"
 #include <iostream>
 
 namespace mfast {

--- a/src/mfast/json/json_decode.cpp
+++ b/src/mfast/json/json_decode.cpp
@@ -4,6 +4,10 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "json.h"
+#include "../enum_ref.h"
+#include "../group_ref.h"
+#include "../field_visitor.h"
+#include "../nested_message_ref.h"
 #include <boost/regex/pending/unicode_iterator.hpp>
 namespace mfast {
 

--- a/src/mfast/json/json_encode.cpp
+++ b/src/mfast/json/json_encode.cpp
@@ -4,6 +4,9 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "json.h"
+#include "../enum_ref.h"
+#include "../field_visitor.h"
+#include "../nested_message_ref.h"
 #include <boost/io/ios_state.hpp>
 #include <cstdio>
 #ifdef _MSC_VER // someday someone at microsoft will read the C++11 standard.

--- a/src/mfast/malloc_allocator.cpp
+++ b/src/mfast/malloc_allocator.cpp
@@ -4,6 +4,8 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "malloc_allocator.h"
+#include <algorithm>
+#include <new>
 
 namespace mfast {
 

--- a/src/mfast/malloc_allocator.h
+++ b/src/mfast/malloc_allocator.h
@@ -6,7 +6,6 @@
 #pragma once
 #include "allocator.h"
 #include <cstdlib>
-#include <new>
 
 namespace mfast {
 class MFAST_EXPORT malloc_allocator : public allocator {

--- a/src/mfast/message_ref.h
+++ b/src/mfast/message_ref.h
@@ -6,10 +6,9 @@
 #pragma once
 
 #include <cassert>
-#include "field_instructions.h"
 #include "allocator.h"
 #include "field_ref.h"
-#include "group_ref.h"
+#include "aggregate_ref.h"
 // #include "mfast/nested_message_ref.h"
 namespace mfast {
 struct fast_decoder_impl;

--- a/src/mfast/nested_message_ref.h
+++ b/src/mfast/nested_message_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "field_instructions.h"
 #include "field_ref.h"
 #include "message_ref.h"
 #include "type_category.h"

--- a/src/mfast/sequence_ref.cpp
+++ b/src/mfast/sequence_ref.cpp
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #include "mfast/sequence_ref.h"
 #include "mfast/allocator.h"
-#include <limits>
 
 namespace mfast {
 namespace detail {

--- a/src/mfast/sequence_ref.h
+++ b/src/mfast/sequence_ref.h
@@ -5,9 +5,7 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "field_instructions.h"
 #include "field_ref.h"
-#include "group_ref.h"
 #include "aggregate_ref.h"
 
 #include <cassert>

--- a/src/mfast/set_ref.h
+++ b/src/mfast/set_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "mfast/field_instructions.h"
 #include "mfast/field_ref.h"
 #include "mfast/type_category.h"
 

--- a/src/mfast/string_ref.h
+++ b/src/mfast/string_ref.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <string>
 #include "field_ref.h"
 #include "vector_ref.h"
 #include <boost/utility/string_ref.hpp>

--- a/src/mfast/vector_ref.h
+++ b/src/mfast/vector_ref.h
@@ -8,7 +8,6 @@
 #include <iterator>
 #include <cstring>
 #include <vector>
-#include <limits>
 #include "field_ref.h"
 #include "allocator.h"
 #include "type_category.h"

--- a/src/mfast/view_iterator.h
+++ b/src/mfast/view_iterator.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include "field_instructions.h"
 #include "aggregate_ref.h"
 #include "field_ref.h"
 #include <vector>

--- a/src/mfast/xml_parser/FastXMLVisitor.cpp
+++ b/src/mfast/xml_parser/FastXMLVisitor.cpp
@@ -7,7 +7,6 @@
 #include "xml_util.h"
 #include <cstring>
 #include <cstdlib>
-#include <iostream>
 const char *FastXMLVisitor::get_optional_attr(const XMLElement &element,
                                               const char *attr_name,
                                               const char *default_value) const {

--- a/src/mfast/xml_parser/FastXMLVisitor.h
+++ b/src/mfast/xml_parser/FastXMLVisitor.h
@@ -6,8 +6,6 @@
 #pragma once
 #include <stdint.h>
 #include <vector>
-#include <exception>
-#include <fstream>
 #include <string>
 #include <cstring>
 #include <deque>

--- a/src/mfast/xml_parser/dynamic_templates_description.h
+++ b/src/mfast/xml_parser/dynamic_templates_description.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "mfast_xml_parser_export.h"
-#include "../field_instructions.h"
+#include "../instructions/templates_description.h"
 #include "../arena_allocator.h"
 #include "../view_iterator.h"
 #include <deque>

--- a/src/mfast/xml_parser/field_builder.cpp
+++ b/src/mfast/xml_parser/field_builder.cpp
@@ -8,7 +8,6 @@
 #include "../exceptions.h"
 #include <boost/tokenizer.hpp>
 #include <boost/optional.hpp>
-#include "mfast/field_instructions.h"
 
 using namespace tinyxml2;
 

--- a/src/mfast/xml_parser/field_builder_base.h
+++ b/src/mfast/xml_parser/field_builder_base.h
@@ -5,7 +5,6 @@
 // See the file license.txt for licensing information.
 #pragma once
 
-#include <deque>
 #include <map>
 #include "xml_util.h"
 #include "template_registry_impl.h"

--- a/src/mfast/xml_parser/field_op.cpp
+++ b/src/mfast/xml_parser/field_op.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <boost/assign.hpp>
 #include "field_op.h"
+#include "../exceptions.h"
 #include "../instructions/decimal_instruction.h"
 #include "../instructions/byte_vector_instruction.h"
 using namespace boost::assign;

--- a/src/mfast/xml_parser/field_op.h
+++ b/src/mfast/xml_parser/field_op.h
@@ -4,13 +4,10 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #pragma once
-#include <cstring>
-#include <map>
 #include <boost/lexical_cast.hpp>
 #include "../arena_allocator.h"
 #include "../instructions/field_instruction.h"
 #include "xml_util.h"
-#include "../exceptions.h"
 
 namespace mfast {
 class decimal_field_instruction;

--- a/src/mfast/xml_parser/templates_builder.cpp
+++ b/src/mfast/xml_parser/templates_builder.cpp
@@ -4,6 +4,7 @@
 // This file is part of mFAST.
 // See the file license.txt for licensing information.
 #include "templates_builder.h"
+#include "field_builder.h"
 #include "../boolean_ref.h"
 #include "view_info_builder.h"
 #include "../exceptions.h"

--- a/src/mfast/xml_parser/templates_builder.h
+++ b/src/mfast/xml_parser/templates_builder.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <string>
-#include "../field_instructions.h"
 #include "tinyxml2.h"
-#include "field_builder.h"
+#include "field_builder_base.h"
 #include "dynamic_templates_description.h"
 #include <boost/utility.hpp>
 

--- a/src/mfast/xml_parser/view_info_builder.cpp
+++ b/src/mfast/xml_parser/view_info_builder.cpp
@@ -1,5 +1,4 @@
 #include <cstring>
-#include <string.h>
 #include "view_info_builder.h"
 #include "xml_util.h"
 #include "../exceptions.h"


### PR DESCRIPTION
This is just a cleanup of include statements.
Previously there were some includes that weren't used at all and others that were used only because they transitively included other files.
By removing unnecessary includes and by moving useful ones from header files into cpp files, this change dimishes the amount of preprocessed code that is fed to the compiler, perhaps improving the parsing (useful for IDEs as well) and compilation time.

These changes are meant not to have any functional impact on the code itself.